### PR TITLE
feat: add aggregator integration test scripts

### DIFF
--- a/scripts/aggregator/config/general.yaml
+++ b/scripts/aggregator/config/general.yaml
@@ -1,0 +1,37 @@
+analysis:
+  n_cores: 1
+psf:
+  use_fft_default: false              # If True, PSFs are convolved using FFTs by default, which is faster and uses less memory in all cases except for very small PSFs, False uses direct convolution.
+hpc:
+  hpc_mode: false
+  iterations_per_full_update: 5000
+adapt:
+  adapt_minimum_percent: 0.01
+  adapt_noise_limit: 100000000.0
+inversion:
+  check_reconstruction: false       # If True, the inversion's reconstruction is checked to ensure the solution of a meshs's mapper is not an invalid solution where the values are all the same.
+  use_positive_only_solver: false    # If True, inversion's use a positive-only linear algebra solver by default, which is slower but prevents unphysical negative values in the reconstructed solutuion.
+  no_regularization_add_to_curvature_diag_value: 1.0e-8 # The default value added to the curvature matrix's diagonal when regularization is not applied to a linear object, which prevents inversion's failing due to the matrix being singular.
+  positive_only_uses_p_initial: false  # If True, the positive-only solver of an inversion's uses an initial guess of the reconstructed data's values as which values should be positive, speeding up the solver.
+  use_border_relocator: false          # If True, by default a pixelization's border is used to relocate all pixels outside its border to the border.
+numba:
+  cache: true
+  nopython: true
+  parallel: false
+  use_numba: true
+output:
+  force_pickle_overwrite: false
+  info_whitespace_length: 80
+  log_file: output.log
+  log_level: INFO
+  log_to_file: false
+  model_results_decimal_places: 3
+  remove_files: false
+  samples_to_csv: false
+profiling:
+  perform: true
+  repeats: 1
+test:
+  check_likelihood_function: false  # if True, when a search is resumed the likelihood of a previous sample is recalculated to ensure it is consistent with the previous run.
+  exception_override: false
+  disable_positions_lh_inversion_check: false

--- a/scripts/aggregator/config/non_linear.yaml
+++ b/scripts/aggregator/config/non_linear.yaml
@@ -1,0 +1,75 @@
+mock:
+  MockOptimizer:
+    initialize:
+      method: prior
+    printing:
+      silence: false
+
+  MockSearch:
+    initialize:
+      method: prior
+    printing:
+      silence: false
+    search: {}
+
+nest:
+  DynestyDynamic:
+    general:
+      acceptance_ratio_threshold: 0.1
+      bootstrap: null
+      bound: multi
+      enlarge: null
+      first_update: null
+      fmove: 0.9
+      max_move: 100
+      sample: auto
+      sampling_efficiency: 0.5
+      slices: 5
+      terminate_at_acceptance_ratio: false
+      update_interval: null
+      walks: 25
+    initialize:
+      method: prior
+    parallel:
+      force_x1_cpu: false
+      number_of_cores: 1
+    printing:
+      silence: false
+
+  DynestyStatic:
+    parallel:
+      number_of_cores: 1
+    initialize:
+      method: prior
+    inversion:
+      acceptance_ratio_threshold: 0.05
+      const_efficiency_mode: true
+      evidence_tolerance: 100.0
+      multimodal: false
+      n_live_points: 50
+      sampling_efficiency: 0.3
+      terminate_at_acceptance_ratio: false
+    printing:
+      silence: false
+    search:
+      const_efficiency_mode: false
+      evidence_tolerance: 0.5
+      importance_nested_sampling: false
+      max_iter: 0
+      max_modes: 100
+      mode_tolerance: -1.0e+90
+      multimodal: false
+      n_live_points: 50
+      sampling_efficiency: 0.5
+    settings:
+      context: 0
+      init_MPI: false
+      log_zero: -1.0e+100
+      n_iter_before_update: 5
+      null_log_evidence: -1.0e+90
+      resume: true
+      seed: -1.0
+      stagger_resampling_likelihood: true
+      verbose: false
+      write_output: true
+

--- a/scripts/aggregator/config/notation.yaml
+++ b/scripts/aggregator/config/notation.yaml
@@ -1,0 +1,83 @@
+label:
+  label:
+    alpha: \alpha
+    angle_binary: \theta
+    beta: \beta
+    break_radius: \theta_{\rm B}
+    centre_0: y
+    centre_1: x
+    coefficient: \lambda
+    contribution_factor: \omega_{\rm 0}
+    core_radius: C_{\rm r}
+    core_radius_0: C_{rm r0}
+    core_radius_1: C_{\rm r1}
+    effective_radius: R_{\rm eff}
+    einstein_radius: \theta_{\rm Ein}
+    ell_comps_0: \epsilon_{\rm 1}
+    ell_comps_1: \epsilon_{\rm 2}
+    multipole_comps_0: M_{\rm 1}
+    multipole_comps_1: M_{\rm 2}
+    flux: F
+    gamma: \gamma
+    gamma_1: \gamma
+    gamma_2: \gamma
+    inner_coefficient: \lambda_{\rm 1}
+    inner_slope: t_{\rm 1}
+    intensity: I_{\rm b}
+    kappa: \kappa
+    kappa_s: \kappa_{\rm s}
+    log10m_vir: log_{\rm 10}(m_{vir})
+    m: m
+    mass: M
+    mass_at_200: M_{\rm 200}
+    mass_ratio: M_{\rm ratio}
+    mass_to_light_gradient: \Gamma
+    mass_to_light_ratio: \Psi
+    mass_to_light_ratio_base: \Psi_{\rm base}
+    mass_to_light_radius: R_{\rm ref}
+    noise_factor: \omega_{\rm 1}
+    noise_power: \omega{\rm 2}
+    noise_scale: \sigma_{\rm 1}
+    normalization_scale: n
+    outer_coefficient: \lambda_{\rm 2}
+    outer_slope: t_{\rm 2}
+    overdens: \Delta_{\rm vir}
+    pixels: N_{\rm pix}
+    radius_break: R_{\rm b}
+    redshift: z
+    redshift_object: z_{\rm obj}
+    redshift_source: z_{\rm src}
+    scale_radius: R_{\rm s}
+    scatter: \sigma
+    separation: s
+    sersic_index: n
+    shape_0: y_{\rm pix}
+    shape_1: x_{\rm pix}
+    sigma: \sigma
+    signal_scale: V
+    sky_scale: \sigma_{\rm 0}
+    slope: \gamma
+    truncation_radius: R_{\rm t}
+    weight_floor: W_{\rm f}
+    weight_power: W_{\rm p}
+  superscript:
+    ExternalShear: ext
+    Pixelization: pix
+    Point: point
+    Redshift: ''
+    Regularization: reg
+label_format:
+  format:
+    angular_diameter_distance_to_earth: '{:.2f}'
+    concentration: '{:.2f}'
+    einstein_mass: '{:.4e}'
+    einstein_radius: '{:.2f}'
+    kpc_per_arcsec: '{:.2f}'
+    luminosity: '{:.4e}'
+    m: '{:.1f}'
+    mass: '{:.4e}'
+    mass_at_truncation_radius: '{:.4e}'
+    radius: '{:.2f}'
+    redshift: '{:.2f}'
+    rho: '{:.2f}'
+    sersic_luminosity: '{:.4e}'

--- a/scripts/aggregator/config/output.yaml
+++ b/scripts/aggregator/config/output.yaml
@@ -1,0 +1,63 @@
+# Determines whether files saved by the search are output to the hard-disk. This is true both when saving to the
+# directory structure and when saving to database.
+
+# Files can be listed name: bool where the name is the name of the file without a suffix (e.g. model not model.json)
+# and bool is true or false.
+
+# If a given file is not listed then the default value is used.
+
+default: true # If true then files which are not explicitly listed here are output anyway. If false then they are not.
+
+### Samples ###
+
+# The `samples.csv`file contains every sampled value of every free parameter with its log likelihood and weight.
+
+# This file is often large, therefore disabling it can significantly reduce hard-disk space use.
+
+# `samples.csv` is used to perform marginalization, infer model parameter errors and do other analysis of the search
+# chains. Even if output of `samples.csv` is disabled, these tasks are still performed by the fit and output to
+# the `samples_summary.json` file. However, without a `samples.csv` file these types of tasks cannot be performed
+# after the fit is complete, for example via the database.
+
+samples: true
+
+# The `samples.csv` file contains every accepted sampled value of every free parameter with its log likelihood and
+# weight. For certain searches, the majority of samples have a very low weight, which has no numerical impact on the
+# results of the model-fit. However, these samples are still output to the `samples.csv` file, taking up hard-disk space
+# and slowing down analysis of the samples (e.g. via the database).
+
+# The `samples_weight_threshold` below specifies the threshold value of the weight such that samples with a weight
+# below this value are not output to the `samples.csv` file. This can be used to reduce the size of the `samples.csv`
+# file and speed up analysis of the samples.
+
+# Note that for many searches (e.g. MCMC) all samples have equal weight, and thus this threshold has no impact and
+# there is no simple way to save hard-disk space. However, for nested sampling, the majority of samples have a very
+# low weight and this threshold can be used to save hard-disk space.
+
+# Set value to empty (e.g. delete 1.0e-10 below) to disable this feature.
+
+samples_weight_threshold: 1.0e-10
+
+### Search Internal ###
+
+# The search internal folder which contains a saved state of the non-linear search, as a .pickle or .dill file.
+
+# If the entry below is false, the folder is still output during the model-fit, as it is required to resume the fit
+# from where it left off. Therefore, settings `false` below does not impact model-fitting checkpointing and resumption.
+# Instead, the search internal folder is deleted once the fit is completed.
+
+# The search internal folder file is often large, therefore deleting it after a fit is complete can significantly
+# reduce hard-disk space use.
+
+# The search internal representation (e.g. what you can load from the output .pickle file) may have additional
+# quantities specific to the non-linear search that you are interested in inspecting. Deleting the folder means this
+# information is list.
+
+search_internal: false
+
+# Other Files:
+
+covariance: false # `covariance.csv`: The [free parameters x free parameters] covariance matrix.
+data: true # `data.json`: The value of every data point in the data.
+noise_map: true # `noise_map.json`: The value of every RMS noise map value.
+

--- a/scripts/aggregator/config/priors/dark_mass_profiles.yaml
+++ b/scripts/aggregator/config/priors/dark_mass_profiles.yaml
@@ -1,0 +1,314 @@
+NFW:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  kappa_s:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  scale_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+NFWSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  kappa_s:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  scale_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+NFWTruncatedSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  kappa_s:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  scale_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  truncation_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+SphNFWTruncatedMCR:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  mass_at_200:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 100000000.0
+    type: LogUniform
+    upper_limit: 1000000000000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+gNFW:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  inner_slope:
+    limits:
+      lower: -1.0
+      upper: 3.0
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 2.0
+    width_modifier:
+      type: Absolute
+      value: 0.3
+  kappa_s:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  scale_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+gNFWSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  inner_slope:
+    limits:
+      lower: -1.0
+      upper: 3.0
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 2.0
+    width_modifier:
+      type: Absolute
+      value: 0.3
+  kappa_s:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+  scale_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2

--- a/scripts/aggregator/config/priors/galaxy.yaml
+++ b/scripts/aggregator/config/priors/galaxy.yaml
@@ -1,0 +1,17 @@
+Galaxy:
+  redshift:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 3.0
+
+Redshift:
+  redshift:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 3.0
+    width_modifier:
+      type: Absolute
+      value: 1.0

--- a/scripts/aggregator/config/priors/geometry_profiles.yaml
+++ b/scripts/aggregator/config/priors/geometry_profiles.yaml
@@ -1,0 +1,48 @@
+AbstractSersic:
+  angle:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 180.0
+  axis_ratio:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  centre_0:
+    lower_limit: -1.0
+    type: Uniform
+    upper_limit: 1.0
+  centre_1:
+    lower_limit: -1.0
+    type: Uniform
+    upper_limit: 1.0
+  effective_radius:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 3.0
+  intensity:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  sersic_index:
+    lower_limit: 0.6
+    type: Uniform
+    upper_limit: 8.0
+EllProfile:
+  angle:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 2.0
+  axis_ratio:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 2.0
+GeometryProfile:
+  centre_0:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  centre_1:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+SphlProfile: {}

--- a/scripts/aggregator/config/priors/light_profiles.yaml
+++ b/scripts/aggregator/config/priors/light_profiles.yaml
@@ -1,0 +1,250 @@
+EllLightProfile:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.5
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    mean: 0.0
+    sigma: 0.5
+    type: Gaussian
+    width_modifier:
+      type: Relative
+      value: 0.5
+Exponential:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.5
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 2.0
+    width_modifier:
+      type: Absolute
+      value: 2.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    mean: 0.0
+    sigma: 0.5
+    type: Gaussian
+    width_modifier:
+      type: Relative
+      value: 0.5
+Gaussian:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  sigma:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 25.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+Sersic:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  sersic_index:
+    limits:
+      lower: 0.5
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 8.0
+    width_modifier:
+      type: Absolute
+      value: 1.5

--- a/scripts/aggregator/config/priors/mass_sheets.yaml
+++ b/scripts/aggregator/config/priors/mass_sheets.yaml
@@ -1,0 +1,21 @@
+ExternalShear:
+  gamma_1:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: -0.2
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  gamma_2:
+    limits:
+      lower: -inf
+      upper: inf
+    lower_limit: -0.2
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.05

--- a/scripts/aggregator/config/priors/pixelizations.yaml
+++ b/scripts/aggregator/config/priors/pixelizations.yaml
@@ -1,0 +1,125 @@
+delaunay.DelaunayBrightnessImage:
+  pixels:
+    limits:
+      lower: 50.0
+      upper: inf
+    lower_limit: 50.0
+    type: Uniform
+    upper_limit: 2500.0
+    width_modifier:
+      type: Absolute
+      value: 100.0
+  weight_floor:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  weight_power:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 20.0
+    width_modifier:
+      type: Absolute
+      value: 5.0
+delaunay.DelaunayMagnification:
+  shape_0:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+  shape_1:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+rectangular.RectangularAdaptDensity:
+  shape_0:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+  shape_1:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+voronoi.VoronoiBrightnessImage:
+  pixels:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 50.0
+    type: Uniform
+    upper_limit: 1500.0
+    width_modifier:
+      type: Absolute
+      value: 400.0
+  weight_floor:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  weight_power:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 20.0
+    width_modifier:
+      type: Absolute
+      value: 5.0
+voronoi.VoronoiMagnification:
+  shape_0:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0
+  shape_1:
+    limits:
+      lower: 3.0
+      upper: inf
+    lower_limit: 20.0
+    type: Uniform
+    upper_limit: 45.0
+    width_modifier:
+      type: Absolute
+      value: 8.0

--- a/scripts/aggregator/config/priors/regularization.yaml
+++ b/scripts/aggregator/config/priors/regularization.yaml
@@ -1,0 +1,39 @@
+adaptive_brightness.Adapt:
+  inner_coefficient:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  outer_coefficient:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+  signal_scale:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+constant.Constant:
+  coefficient:
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 1.0
+constant_zeorth.ConstantZeroth:
+  coefficient_neighbor:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  coefficient_zeroth:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5

--- a/scripts/aggregator/config/priors/stellar_mass_profiles.yaml
+++ b/scripts/aggregator/config/priors/stellar_mass_profiles.yaml
@@ -1,0 +1,564 @@
+DevVaucouleurs:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+DevVaucouleursSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+Exponential:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+ExponentialSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+Sersic:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+  sersic_index:
+    limits:
+      lower: 0.8
+      upper: 5.0
+    lower_limit: 0.8
+    type: Uniform
+    upper_limit: 5.0
+    width_modifier:
+      type: Absolute
+      value: 1.5
+SersicGradient:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_gradient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: -1.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+  sersic_index:
+    limits:
+      lower: 0.8
+      upper: 5.0
+    lower_limit: 0.8
+    type: Uniform
+    upper_limit: 5.0
+    width_modifier:
+      type: Absolute
+      value: 1.5
+SersicGradientSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_gradient:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: -1.0
+    type: Uniform
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+  sersic_index:
+    limits:
+      lower: 0.8
+      upper: 5.0
+    lower_limit: 0.8
+    type: Uniform
+    upper_limit: 5.0
+    width_modifier:
+      type: Absolute
+      value: 1.5
+SersicSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  effective_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 1.0
+  intensity:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+  mass_to_light_ratio:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 1.0e-06
+    type: LogUniform
+    upper_limit: 1000.0
+    width_modifier:
+      type: Relative
+      value: 0.3
+  sersic_index:
+    limits:
+      lower: 0.8
+      upper: 5.0
+    lower_limit: 0.8
+    type: Uniform
+    upper_limit: 5.0
+    width_modifier:
+      type: Absolute
+      value: 1.5

--- a/scripts/aggregator/config/priors/total_mass_profiles.yaml
+++ b/scripts/aggregator/config/priors/total_mass_profiles.yaml
@@ -1,0 +1,455 @@
+Isothermal:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+IsothermalCore:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  core_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+IsothermalCoreSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  core_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+IsothermalSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+PointMass:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 8.0
+    width_modifier:
+      type: Relative
+      value: 0.25
+PowerLaw:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  slope:
+    limits:
+      lower: 1.0
+      upper: 3.0
+    lower_limit: 1.5
+    type: Uniform
+    upper_limit: 3.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+PowerLawCore:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  core_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  ell_comps_0:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  ell_comps_1:
+    limits:
+      lower: -1.0
+      upper: 1.0
+    lower_limit: -1.0
+    mean: 0.0
+    sigma: 0.3
+    type: TruncatedGaussian
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+  slope:
+    limits:
+      lower: 1.0
+      upper: 3.0
+    lower_limit: 1.5
+    type: Uniform
+    upper_limit: 3.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+PowerLawCoreSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  core_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 0.2
+    width_modifier:
+      type: Absolute
+      value: 0.1
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  slope:
+    limits:
+      lower: 1.0
+      upper: 3.0
+    lower_limit: 1.5
+    type: Uniform
+    upper_limit: 3.0
+    width_modifier:
+      type: Absolute
+      value: 0.2
+PowerLawSph:
+  centre_0:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  centre_1:
+    limits:
+      lower: -inf
+      upper: inf
+    mean: 0.0
+    sigma: 0.3
+    type: Gaussian
+    width_modifier:
+      type: Absolute
+      value: 0.05
+  einstein_radius:
+    limits:
+      lower: 0.0
+      upper: inf
+    lower_limit: 0.0
+    type: Uniform
+    upper_limit: 4.0
+    width_modifier:
+      type: Relative
+      value: 0.05
+  slope:
+    limits:
+      lower: 1.0
+      upper: 3.0
+    lower_limit: 1.5
+    type: Uniform
+    upper_limit: 3.0
+    width_modifier:
+      type: Absolute
+      value: 0.2

--- a/scripts/aggregator/config/visualize.yaml
+++ b/scripts/aggregator/config/visualize.yaml
@@ -1,0 +1,42 @@
+general:
+  general:
+    backend: default
+    imshow_origin: upper
+    zoom_around_mask: true
+plots:
+  fits_are_zoomed: true
+  dataset:
+    subplot_dataset: true
+  fit:
+    subplot_fit: true
+    subplots_of_planes: false
+    fits_fit: true                          # Output a .fits file containing the fit model data, residual map, normalized residual map and chi-squared?
+    fits_galaxy_images : true                # Output a .fits file containing the images (e.g. without PSF convolution) of every galaxy?
+    fits_model_galaxy_images : true          # Output a .fits file containing the model images (e.g. with PSF convolution) of every galaxy?
+  fit_imaging:
+    subplot_fit_log10: true
+    subplot_of_planes: true
+  fit_interferometer:
+    subplot_fit_real_space: true
+    subplot_fit_dirty_images: true
+    fits_dirty_images: true                 # output dirty_images.fits showing the dirty image, noise-map, model-data, resiual-map, normalized residual map and chi-squared map?
+  fit_point_dataset: {}
+  fit_quantity:
+    subplot_fit: true
+  galaxies:
+    subplot_galaxies: true
+    subplot_galaxy_images: true
+    subplot_galaxies_1d: true
+    subplot_galaxies_1d_decomposed: true
+  adapt:
+    subplot_adapt_images: true
+  inversion:
+    subplot_inversion: true
+  positions:
+    image_with_positions: true
+  tracer:
+    subplot_tracer: true
+    subplot_galaxies_images: true
+    fits_tracer: true                       # Output tracer.fits file of tracer's convergence, potential, deflections_y and deflections_x?
+    fits_source_plane_images: true           # Output source_plane_images.fits file of the source-plane image (light profiles only) of each galaxy in the tracer?
+    fits_source_plane_shape: (3, 3)      # The shape of the source-plane image output in the fits_source_plane_images.fits file.

--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -1,0 +1,162 @@
+"""
+Integration test: aggregator FitImaging scrape.
+
+Exercises FitImagingAgg randomly_drawn_via_pdf_gen_from,
+all_above_weight_gen_from, and adapt_images round-trip.
+"""
+import os
+import shutil
+from os import path
+
+from autoconf import conf
+from autoconf.conf import with_config
+import autofit as af
+import autolens as al
+from autolens import fixtures
+from autofit.non_linear.samples import Sample
+
+os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+
+directory = path.dirname(path.realpath(__file__))
+
+conf.instance.push(
+    new_path=path.join(directory, "config"),
+    output_path=path.join(directory, "output"),
+)
+
+database_file = "db_fit_imaging"
+
+
+def clean():
+    database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    if path.exists(database_sqlite):
+        os.remove(database_sqlite)
+    result_path = path.join(conf.instance.output_path, database_file)
+    if path.exists(result_path):
+        shutil.rmtree(result_path)
+
+
+@with_config("general", "output", "samples_to_csv", value=True)
+def aggregator_from(analysis, model, samples):
+    result_path = path.join(conf.instance.output_path, database_file)
+    clean()
+    search = al.m.MockSearch(
+        samples=samples, result=al.m.MockResult(model=model, samples=samples)
+    )
+    search.paths = af.DirectoryPaths(path_prefix=database_file)
+    search.fit(model=model, analysis=analysis)
+    analysis.modify_before_fit(paths=search.paths, model=model)
+    analysis.visualize_before_fit(paths=search.paths, model=model)
+    db_path = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    agg = af.Aggregator.from_database(filename=db_path)
+    agg.add_directory(directory=result_path)
+    return agg
+
+
+def make_model():
+    dataset_model = af.Model(al.DatasetModel)
+    dataset_model.background_sky_level = af.UniformPrior(
+        lower_limit=0.5, upper_limit=1.5
+    )
+    return af.Collection(
+        dataset_model=dataset_model,
+        galaxies=af.Collection(
+            lens=af.Model(al.Galaxy, redshift=0.5, light=al.lp.Sersic),
+            source=af.Model(al.Galaxy, redshift=1.0, light=al.lp.Sersic),
+        ),
+    )
+
+
+def make_samples(model):
+    parameters = [model.prior_count * [1.0], model.prior_count * [10.0]]
+    sample_list = Sample.from_lists(
+        model=model,
+        parameter_lists=parameters,
+        log_likelihood_list=[1.0, 2.0],
+        log_prior_list=[0.0, 0.0],
+        weight_list=[0.0, 1.0],
+    )
+    return al.m.MockSamples(
+        model=model,
+        sample_list=sample_list,
+        prior_means=[1.0] * model.prior_count,
+    )
+
+
+model = make_model()
+samples = make_samples(model)
+analysis = fixtures.make_analysis_imaging_7x7()
+adapt_images = fixtures.make_adapt_images_7x7()
+
+# --- Test 1: randomly_drawn_via_pdf_gen_from ---
+
+print("Test 1: fit_imaging_randomly_drawn_via_pdf_gen_from ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitImagingAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.randomly_drawn_via_pdf_gen_from(total_samples=2)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+        assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
+        assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+        assert fit_list[0].dataset_model.background_sky_level == 10.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+# --- Test 2: all_above_weight_gen_from ---
+
+print("Test 2: fit_imaging_all_above_weight_gen ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitImagingAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.all_above_weight_gen_from(minimum_weight=-1.0)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        if i == 1:
+            assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+            assert fit_list[0].tracer.galaxies[0].light.centre == (1.0, 1.0)
+            assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+        if i == 2:
+            assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+            assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
+            assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+# --- Test 3: adapt_images round-trip ---
+
+print("Test 3: fit_imaging_adapt_images ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitImagingAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.randomly_drawn_via_pdf_gen_from(total_samples=2)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        assert (
+            list(fit_list[0].adapt_images.galaxy_image_dict.values())[0]
+            == list(adapt_images.galaxy_name_image_dict.values())[0]
+        ).all()
+        assert (
+            list(fit_list[0].adapt_images.galaxy_image_plane_mesh_grid_dict.values())[0]
+            == list(adapt_images.galaxy_name_image_plane_mesh_grid_dict.values())[0]
+        ).all()
+assert i == 2
+clean()
+
+print("PASSED")
+
+print("\nAll fit_imaging aggregator tests passed.")

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -1,0 +1,162 @@
+"""
+Integration test: aggregator FitInterferometer scrape.
+
+Exercises FitInterferometerAgg randomly_drawn_via_pdf_gen_from,
+all_above_weight_gen_from, and adapt_images round-trip.
+"""
+import os
+import shutil
+from os import path
+
+from autoconf import conf
+from autoconf.conf import with_config
+import autofit as af
+import autolens as al
+from autolens import fixtures
+from autofit.non_linear.samples import Sample
+
+os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+
+directory = path.dirname(path.realpath(__file__))
+
+conf.instance.push(
+    new_path=path.join(directory, "config"),
+    output_path=path.join(directory, "output"),
+)
+
+database_file = "db_fit_interferometer"
+
+
+def clean():
+    database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    if path.exists(database_sqlite):
+        os.remove(database_sqlite)
+    result_path = path.join(conf.instance.output_path, database_file)
+    if path.exists(result_path):
+        shutil.rmtree(result_path)
+
+
+@with_config("general", "output", "samples_to_csv", value=True)
+def aggregator_from(analysis, model, samples):
+    result_path = path.join(conf.instance.output_path, database_file)
+    clean()
+    search = al.m.MockSearch(
+        samples=samples, result=al.m.MockResult(model=model, samples=samples)
+    )
+    search.paths = af.DirectoryPaths(path_prefix=database_file)
+    search.fit(model=model, analysis=analysis)
+    analysis.modify_before_fit(paths=search.paths, model=model)
+    analysis.visualize_before_fit(paths=search.paths, model=model)
+    db_path = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    agg = af.Aggregator.from_database(filename=db_path)
+    agg.add_directory(directory=result_path)
+    return agg
+
+
+def make_model():
+    dataset_model = af.Model(al.DatasetModel)
+    dataset_model.background_sky_level = af.UniformPrior(
+        lower_limit=0.5, upper_limit=1.5
+    )
+    return af.Collection(
+        dataset_model=dataset_model,
+        galaxies=af.Collection(
+            lens=af.Model(al.Galaxy, redshift=0.5, light=al.lp.Sersic),
+            source=af.Model(al.Galaxy, redshift=1.0, light=al.lp.Sersic),
+        ),
+    )
+
+
+def make_samples(model):
+    parameters = [model.prior_count * [1.0], model.prior_count * [10.0]]
+    sample_list = Sample.from_lists(
+        model=model,
+        parameter_lists=parameters,
+        log_likelihood_list=[1.0, 2.0],
+        log_prior_list=[0.0, 0.0],
+        weight_list=[0.0, 1.0],
+    )
+    return al.m.MockSamples(
+        model=model,
+        sample_list=sample_list,
+        prior_means=[1.0] * model.prior_count,
+    )
+
+
+model = make_model()
+samples = make_samples(model)
+analysis = fixtures.make_analysis_interferometer_7()
+adapt_images = fixtures.make_adapt_images_7x7()
+
+# --- Test 1: randomly_drawn_via_pdf_gen_from ---
+
+print("Test 1: fit_interferometer_randomly_drawn_via_pdf_gen_from ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitInterferometerAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.randomly_drawn_via_pdf_gen_from(total_samples=2)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+        assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
+        assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+        assert fit_list[0].dataset_model.background_sky_level == 10.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+# --- Test 2: all_above_weight_gen_from ---
+
+print("Test 2: fit_interferometer_all_above_weight_gen ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitInterferometerAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.all_above_weight_gen_from(minimum_weight=-1.0)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        if i == 1:
+            assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+            assert fit_list[0].tracer.galaxies[0].light.centre == (1.0, 1.0)
+            assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+        if i == 2:
+            assert fit_list[0].tracer.galaxies[0].redshift == 0.5
+            assert fit_list[0].tracer.galaxies[0].light.centre == (10.0, 10.0)
+            assert fit_list[0].tracer.galaxies[1].redshift == 1.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+# --- Test 3: adapt_images round-trip ---
+
+print("Test 3: fit_interferometer_adapt_images ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+fit_agg = al.agg.FitInterferometerAgg(aggregator=agg)
+fit_pdf_gen = fit_agg.randomly_drawn_via_pdf_gen_from(total_samples=2)
+
+i = 0
+for fit_gen in fit_pdf_gen:
+    for fit_list in fit_gen:
+        i += 1
+        assert (
+            list(fit_list[0].adapt_images.galaxy_image_dict.values())[0]
+            == list(adapt_images.galaxy_name_image_dict.values())[0]
+        ).all()
+        assert (
+            list(fit_list[0].adapt_images.galaxy_image_plane_mesh_grid_dict.values())[0]
+            == list(adapt_images.galaxy_name_image_plane_mesh_grid_dict.values())[0]
+        ).all()
+assert i == 2
+clean()
+
+print("PASSED")
+
+print("\nAll fit_interferometer aggregator tests passed.")

--- a/scripts/aggregator/tracer.py
+++ b/scripts/aggregator/tracer.py
@@ -1,0 +1,143 @@
+"""
+Integration test: aggregator Tracer scrape.
+
+Exercises TracerAgg randomly_drawn_via_pdf_gen_from and
+all_above_weight_gen_from with weight verification.
+"""
+import os
+import shutil
+from os import path
+
+from autoconf import conf
+from autoconf.conf import with_config
+import autofit as af
+import autolens as al
+from autolens import fixtures
+from autofit.non_linear.samples import Sample
+
+os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+
+directory = path.dirname(path.realpath(__file__))
+
+conf.instance.push(
+    new_path=path.join(directory, "config"),
+    output_path=path.join(directory, "output"),
+)
+
+database_file = "db_tracer"
+
+
+def clean():
+    database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    if path.exists(database_sqlite):
+        os.remove(database_sqlite)
+    result_path = path.join(conf.instance.output_path, database_file)
+    if path.exists(result_path):
+        shutil.rmtree(result_path)
+
+
+@with_config("general", "output", "samples_to_csv", value=True)
+def aggregator_from(analysis, model, samples):
+    result_path = path.join(conf.instance.output_path, database_file)
+    clean()
+    search = al.m.MockSearch(
+        samples=samples, result=al.m.MockResult(model=model, samples=samples)
+    )
+    search.paths = af.DirectoryPaths(path_prefix=database_file)
+    search.fit(model=model, analysis=analysis)
+    analysis.modify_before_fit(paths=search.paths, model=model)
+    analysis.visualize_before_fit(paths=search.paths, model=model)
+    db_path = path.join(conf.instance.output_path, f"{database_file}.sqlite")
+    agg = af.Aggregator.from_database(filename=db_path)
+    agg.add_directory(directory=result_path)
+    return agg
+
+
+def make_model():
+    dataset_model = af.Model(al.DatasetModel)
+    dataset_model.background_sky_level = af.UniformPrior(
+        lower_limit=0.5, upper_limit=1.5
+    )
+    return af.Collection(
+        dataset_model=dataset_model,
+        galaxies=af.Collection(
+            lens=af.Model(al.Galaxy, redshift=0.5, light=al.lp.Sersic),
+            source=af.Model(al.Galaxy, redshift=1.0, light=al.lp.Sersic),
+        ),
+    )
+
+
+def make_samples(model):
+    parameters = [model.prior_count * [1.0], model.prior_count * [10.0]]
+    sample_list = Sample.from_lists(
+        model=model,
+        parameter_lists=parameters,
+        log_likelihood_list=[1.0, 2.0],
+        log_prior_list=[0.0, 0.0],
+        weight_list=[0.0, 1.0],
+    )
+    return al.m.MockSamples(
+        model=model,
+        sample_list=sample_list,
+        prior_means=[1.0] * model.prior_count,
+    )
+
+
+model = make_model()
+samples = make_samples(model)
+masked_imaging = fixtures.make_masked_imaging_7x7()
+analysis = al.AnalysisImaging(dataset=masked_imaging, use_jax=False)
+
+# --- Test 1: randomly_drawn_via_pdf_gen_from ---
+
+print("Test 1: tracer_randomly_drawn_via_pdf_gen_from ... ", end="")
+
+agg = aggregator_from(analysis=analysis, model=model, samples=samples)
+tracer_agg = al.agg.TracerAgg(aggregator=agg)
+tracer_pdf_gen = tracer_agg.randomly_drawn_via_pdf_gen_from(total_samples=2)
+
+i = 0
+for tracer_gen in tracer_pdf_gen:
+    for tracer_list in tracer_gen:
+        i += 1
+        assert tracer_list[0].galaxies[0].redshift == 0.5
+        assert tracer_list[0].galaxies[0].light.centre == (10.0, 10.0)
+        assert tracer_list[0].galaxies[1].redshift == 1.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+# --- Test 2: all_above_weight_gen_from ---
+
+print("Test 2: tracer_all_above_weight_gen ... ", end="")
+
+analysis_7x7 = fixtures.make_analysis_imaging_7x7()
+agg = aggregator_from(analysis=analysis_7x7, model=model, samples=samples)
+tracer_agg = al.agg.TracerAgg(aggregator=agg)
+tracer_pdf_gen = tracer_agg.all_above_weight_gen_from(minimum_weight=-1.0)
+weight_pdf_gen = tracer_agg.weights_above_gen_from(minimum_weight=-1.0)
+
+i = 0
+for tracer_gen, weight_gen in zip(tracer_pdf_gen, weight_pdf_gen):
+    for tracer_list in tracer_gen:
+        i += 1
+        if i == 1:
+            assert tracer_list[0].galaxies[0].redshift == 0.5
+            assert tracer_list[0].galaxies[0].light.centre == (1.0, 1.0)
+            assert tracer_list[0].galaxies[1].redshift == 1.0
+        if i == 2:
+            assert tracer_list[0].galaxies[0].redshift == 0.5
+            assert tracer_list[0].galaxies[0].light.centre == (10.0, 10.0)
+            assert tracer_list[0].galaxies[1].redshift == 1.0
+    for weight in weight_gen:
+        if i == 0:
+            assert weight == 0.0
+        if i == 1:
+            assert weight == 1.0
+assert i == 2
+clean()
+
+print("PASSED")
+
+print("\nAll tracer aggregator tests passed.")


### PR DESCRIPTION
## Summary

Adds standalone aggregator integration test scripts moved from PyAutoLens unit tests. These scripts exercise FitImagingAgg, FitInterferometerAgg, and TracerAgg database scrape functionality with assertions, suitable for smoke test use.

## Scripts Changed
- `scripts/aggregator/fit_imaging.py` — FitImagingAgg: randomly_drawn_via_pdf_gen, all_above_weight_gen, adapt_images round-trip
- `scripts/aggregator/fit_interferometer.py` — FitInterferometerAgg: same 3 test patterns
- `scripts/aggregator/tracer.py` — TracerAgg: randomly_drawn_via_pdf_gen, all_above_weight_gen with weight verification
- `scripts/aggregator/config/` — config files needed by aggregator tests

## Upstream PR
https://github.com/PyAutoLabs/PyAutoLens/pull/421

## Test Plan
- [x] All 3 scripts run successfully as standalone Python scripts
- [x] All assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)