### PR TITLE
Use should_simulate in JAX auto-simulation blocks

### DIFF
--- a/scripts/jax_likelihood_functions/imaging/delaunay.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay.py
@@ -56,7 +56,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
@@ -55,7 +55,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/lp.py
+++ b/scripts/jax_likelihood_functions/imaging/lp.py
@@ -53,7 +53,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/mge.py
+++ b/scripts/jax_likelihood_functions/imaging/mge.py
@@ -54,7 +54,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/mge_group.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group.py
@@ -54,7 +54,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/rectangular.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular.py
@@ -53,7 +53,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
@@ -56,7 +56,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
@@ -55,7 +55,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/interferometer/mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge.py
@@ -68,7 +68,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/interferometer/mge_group.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge_group.py
@@ -29,7 +29,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/interferometer/rectangular.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular.py
@@ -67,7 +67,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/multi/mge.py
+++ b/scripts/jax_likelihood_functions/multi/mge.py
@@ -26,7 +26,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -56,7 +56,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_path.exists():
+if al.util.dataset.should_simulate(str(dataset_path)):
     import subprocess
     import sys
 


### PR DESCRIPTION
## Summary
Replace `not path.exists(dataset_path)` with `al.util.dataset.should_simulate(dataset_path)` in all 13 JAX likelihood function scripts. This ensures datasets are automatically deleted and re-created when `PYAUTO_WORKSPACE_SMALL_DATASETS` is toggled, preventing shape mismatches between FITS files and masks.

## Scripts Changed
- `scripts/jax_likelihood_functions/imaging/lp.py` — use should_simulate
- `scripts/jax_likelihood_functions/imaging/mge.py` — same
- `scripts/jax_likelihood_functions/imaging/mge_group.py` — same
- `scripts/jax_likelihood_functions/imaging/delaunay.py` — same
- `scripts/jax_likelihood_functions/imaging/delaunay_mge.py` — same
- `scripts/jax_likelihood_functions/imaging/rectangular.py` — same
- `scripts/jax_likelihood_functions/imaging/rectangular_mge.py` — same
- `scripts/jax_likelihood_functions/imaging/rectangular_dspl.py` — same
- `scripts/jax_likelihood_functions/interferometer/mge.py` — same
- `scripts/jax_likelihood_functions/interferometer/rectangular.py` — same
- `scripts/jax_likelihood_functions/interferometer/mge_group.py` — same
- `scripts/jax_likelihood_functions/point_source/point.py` — same (pathlib → str conversion)
- `scripts/jax_likelihood_functions/multi/mge.py` — same

## Upstream PRs
- https://github.com/PyAutoLabs/PyAutoArray/pull/261
- https://github.com/PyAutoLabs/PyAutoGalaxy/pull/336
- https://github.com/PyAutoLabs/PyAutoLens/pull/430

## Test Plan
- [ ] Smoke tests pass for autolens_test workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)