### PR TITLE
fix: plot dirty_image and replace aplt.Output with output_* kwargs

### DIFF
--- a/scripts/interferometer/simulator/with_lens_light.py
+++ b/scripts/interferometer/simulator/with_lens_light.py
@@ -117,7 +117,7 @@ dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)
 """
 Lets plot the simulated interferometer dataset before we output it to fits.
 """
-aplt.plot_array(array=dataset.data)
+aplt.plot_array(array=dataset.dirty_image)
 
 """
 __Output__

--- a/scripts/point_source/simulators/point_source.py
+++ b/scripts/point_source/simulators/point_source.py
@@ -119,7 +119,9 @@ modeling and to `.png` for general inspection.
 aplt.plot_array(array=tracer.image_2d_from(grid=grid))
 aplt.plot_array(
     array=tracer.image_2d_from(grid=grid),
-    output=aplt.Output(path=dataset_path, format="png"),
+    output_path=dataset_path,
+    output_filename="image",
+    output_format="png",
 )
 
 """
@@ -147,7 +149,7 @@ __Visualize__
 Output a subplot of the simulated point source dataset and the tracer's quantities to the dataset path as .png files.
 """
 aplt.subplot_tracer(
-    tracer=tracer, grid=grid, output=aplt.Output(path=dataset_path, format="png")
+    tracer=tracer, grid=grid, output_path=dataset_path, output_format="png"
 )
 
 """


### PR DESCRIPTION
## Summary
Category F fixes across two simulator scripts:

- **`interferometer/simulator/with_lens_light.py`** — `aplt.plot_array(array=dataset.data)` tried to plot raw interferometer visibilities (complex ndarray) through the Array2D plotter, which expects a masked image. Use `dataset.dirty_image` (inverse Fourier transform into real space) — a proper Array2D.

- **`point_source/simulators/point_source.py`** — `aplt.Output` is no longer exported from `autolens.plot`. Replace `output=aplt.Output(path=..., format="png")` with the `output_path=`, `output_filename=`, `output_format=` kwargs supported directly by `plot_array` and `subplot_tracer`.

## Test plan
- [x] `python scripts/point_source/simulators/point_source.py` — EXIT=0, .png files written.
- [x] `python scripts/interferometer/simulator/with_lens_light.py` — passes line 120 cleanly. (Further failure at line 127 is Category C — `output_to_fits` removed, to be fixed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)