### PR TITLE
fix: migrate interferometer/simulator/with_lens_light.py to current APIs

### DIFF
--- a/scripts/interferometer/simulator/with_lens_light.py
+++ b/scripts/interferometer/simulator/with_lens_light.py
@@ -124,7 +124,8 @@ __Output__
 
 Output the simulated dataset to the dataset path as .fits files.
 """
-dataset.output_to_fits(
+aplt.fits_interferometer(
+    dataset=dataset,
     data_path=path.join(dataset_path, "data.fits"),
     noise_map_path=path.join(dataset_path, "noise_map.fits"),
     uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
@@ -142,9 +143,14 @@ __Visualize__
 
 Output a subplot of the simulated dataset, the image and the tracer's quantities to the dataset path as .png files.
 """
-aplt.plot_array(array=dataset.data, output=aplt.Output(path=dataset_path, format="png"))
+aplt.plot_array(
+    array=dataset.dirty_image,
+    output_path=dataset_path,
+    output_filename="dirty_image",
+    output_format="png",
+)
 aplt.subplot_tracer(
-    tracer=tracer, grid=grid, output=aplt.Output(path=dataset_path, format="png")
+    tracer=tracer, grid=grid, output_path=dataset_path, output_format="png"
 )
 
 """


### PR DESCRIPTION
## Summary
Category C fix (plus latent Category F cleanup in the same file):

- **Line 127** — `dataset.output_to_fits(...)` → `aplt.fits_interferometer(dataset=dataset, ...)`. Matches the sibling `no_lens_light.py` simulator, which was already migrated.
- **Line 146** — `aplt.plot_array(array=dataset.data, output=aplt.Output(...))` was both passing raw visibilities to an Array2D plotter *and* using the removed `aplt.Output` class. Now uses `dataset.dirty_image` with `output_path=` / `output_filename=` / `output_format=` kwargs.
- **Lines 147-149** — `subplot_tracer(..., output=aplt.Output(...))` → `subplot_tracer(..., output_path=..., output_format=...)`.

## Test plan
- [x] `python scripts/interferometer/simulator/with_lens_light.py` runs end-to-end (EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)