### PR TITLE
fix: unset PYAUTO_FAST_PLOTS for interferometer visualization test

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -43,3 +43,8 @@ overrides:
     unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_mge"
     unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+  # visualization.py asserts subplot PNG files exist on disk, but
+  # PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray so
+  # no file is ever written.
+  - pattern: "interferometer/visualization"
+    unset: [PYAUTO_FAST_PLOTS]


### PR DESCRIPTION
## Summary
`interferometer/visualization.py` asserts that subplot PNG files exist on disk. The workspace default `PYAUTO_FAST_PLOTS=1` short-circuits `subplot_save()` in PyAutoArray so no file is ever written, causing the assertion to fail. Add an env_vars.yaml override so fast plots are disabled for this script only.

## Scripts Changed
- `config/build/env_vars.yaml` — add `interferometer/visualization` override unsetting `PYAUTO_FAST_PLOTS`

## Test Plan
- [x] Smoke test: `visualization.py` runs to completion with the full CI env minus `PYAUTO_FAST_PLOTS`, all assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)