### PR TITLE
Skip 4 database/scrape scripts that exceed 60s timeout

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -3,5 +3,14 @@
 #   - Entries with '/' do a substring match against the file path
 #   - Entries without '/' match the file stem exactly
 # Add an inline # comment to document the reason for skipping.
+#
+# SLOW-skip convention:
+#   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
+#   skipped because they exceed the 60s per-script timeout cap. These are
+#   NOT permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Fix the performance issue and remove the SLOW marker.
 
-[]
+- database/scrape/multi_analysis # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_general # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_pix # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode


### PR DESCRIPTION
## Summary

- `_test` workspaces do not run under `PYAUTOFIT_TEST_MODE`, so database scrape scripts execute full non-linear searches
- The four scripts (`multi_analysis`, `slam_general`, `slam_multi_one_by_one`, `slam_pix`) reliably exceed the 60s per-script timeout cap
- Skipped with the new `SLOW <YYYY-MM-DD>` marker so PyAutoBuild surfaces them in a warning banner every mega-run until the performance issue is fixed

Paired with PyAutoBuild PR #40 which adds the SLOW convention and warning banner.

## Test plan

- [x] Pattern matches verified locally
- [ ] Next mega-run shows 0 timeouts from this workspace and warning banner lists all 4 entries