### PR TITLE
fix: plotter API drift in imaging scripts

### DIFF
--- a/scripts/imaging/model_fit.py
+++ b/scripts/imaging/model_fit.py
@@ -199,8 +199,7 @@ aplt.subplot_tracer(tracer=result.max_log_likelihood_tracer, grid=result.grids.l
 
 aplt.subplot_fit_imaging(fit=result.max_log_likelihood_fit)
 
-plotter = aplt.NestPlotter(samples=result.samples)
-plotter.corner_cornerpy()
+aplt.corner_cornerpy(samples=result.samples)
 
 """
 Checkout `autolens_workspace/*/guides/results` for a full description of analysing results.

--- a/scripts/imaging/simulator/no_lens_light.py
+++ b/scripts/imaging/simulator/no_lens_light.py
@@ -129,17 +129,8 @@ al.output_to_json(
 )
 
 """
-Output a subplot of the simulated dataset, the image and a subplot of the `Tracer`'s quantities to the dataset path 
-as .png files.
-"""
-aplt.plot_array(array=dataset.data, output=aplt.Output(path=dataset_path, format="png"))
-aplt.subplot_tracer(
-    tracer=tracer, grid=grid, output=aplt.Output(path=dataset_path, format="png")
-)
-
-"""
-Pickle the `Tracer` in the dataset folder, ensuring the true `Tracer` is safely stored and available if we need to 
-check how the dataset was simulated in the future. 
+Pickle the `Tracer` in the dataset folder, ensuring the true `Tracer` is safely stored and available if we need to
+check how the dataset was simulated in the future.
 
 This will also be accessible via the `Aggregator` if a model-fit is performed using the dataset.
 """


### PR DESCRIPTION
## Summary

Two small plotter API drift fixes in the `_test` workspace:

- `scripts/imaging/simulator/no_lens_light.py`: dropped the `aplt.Output(...)` `.png` export block. `aplt.Output` is no longer re-exported from `autolens.plot`, and these `.png` files were only used for workspace README thumbnails (not needed in the `_test` workspace).
- `scripts/imaging/model_fit.py`: replaced `aplt.NestPlotter(...).corner_cornerpy()` with the top-level helper `aplt.corner_cornerpy(samples=...)`. `NestPlotter` no longer exists.

## Test plan

- [ ] `python scripts/imaging/simulator/no_lens_light.py` runs to completion
- [ ] `python scripts/imaging/model_fit.py` runs to completion
- [ ] Mega-run succeeds on both scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)