### PR TITLE
Park 5 NEEDS_FIX scripts (visualization + JAX)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -9,8 +9,20 @@
 #   skipped because they exceed the 60s per-script timeout cap. These are
 #   NOT permanent skips — every mega-run surfaces them with a loud warning
 #   banner. Fix the performance issue and remove the SLOW marker.
+#
+# NEEDS_FIX convention:
+#   Entries tagged `# NEEDS_FIX <YYYY-MM-DD> - <reason>` mark scripts that
+#   are broken and parked as a to-do list. Like SLOW-skips, these are NOT
+#   permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Investigate the failure, fix the underlying bug, and remove
+#   the NEEDS_FIX marker.
 
 - database/scrape/multi_analysis # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_general # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_pix # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- imaging/visualization # NEEDS_FIX 2026-04-10 - AssertionError: dataset.png missing after visualization refactor
+- jax_likelihood_functions/imaging/delaunay_mge # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
+- jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
+- jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile
+- jax_grad/imaging_mge # NEEDS_FIX 2026-04-10 - AssertionError: Gradient is all zeros in MGE gradient computation


### PR DESCRIPTION
## Summary
Adds the NEEDS_FIX header block and parks 5 scripts failing under the current mega-run env. These are surfaced on every run by the updated slow_skip_check scanner (PyAutoLabs/PyAutoBuild#41).

## API Changes
None — config-only change.

## Test Plan
- [x] `python PyAutoBuild/autobuild/slow_skip_check.py` — 5 NEEDS_FIX entries picked up

Parked scripts:
- `imaging/visualization` — `AssertionError` dataset.png missing after visualization refactor
- `jax_likelihood_functions/imaging/delaunay_mge` — timeout
- `jax_likelihood_functions/imaging/mge_group` — timeout
- `jax_grad/imaging_lp` — JAX traceback in LP gradient
- `jax_grad/imaging_mge` — gradient all zeros

🤖 Generated with [Claude Code](https://claude.com/claude-code)