### PR TITLE
refactor: drop PYAUTO_DISABLE_CRITICAL_CAUSTICS env var

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -11,9 +11,8 @@
 defaults:
   PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
   PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
-  PYAUTO_DISABLE_CRITICAL_CAUSTICS: "1" # Skip critical curve/caustic overlays in plots
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
-  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() in subplots
+  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
@@ -27,7 +26,6 @@ overrides:
     unset:
       - PYAUTOFIT_TEST_MODE
       - PYAUTO_WORKSPACE_SMALL_DATASETS
-      - PYAUTO_DISABLE_CRITICAL_CAUSTICS
       - PYAUTO_DISABLE_JAX
       - PYAUTO_FAST_PLOTS
   # These scripts load pre-committed FITS data at full resolution


### PR DESCRIPTION
## Summary
Remove the retired `PYAUTO_DISABLE_CRITICAL_CAUSTICS` env var from workspace configs. `PYAUTO_FAST_PLOTS=1` now handles both tight_layout skipping and critical curve/caustic overlay skipping.

## Scripts Changed
- `config/build/env_vars.yaml` — removed `PYAUTO_DISABLE_CRITICAL_CAUSTICS` entry and unset reference, updated `PYAUTO_FAST_PLOTS` comment

## Upstream PR
- https://github.com/PyAutoLabs/PyAutoGalaxy/pull/340
- https://github.com/PyAutoLabs/PyAutoBuild/pull/43

## Test Plan
- [x] Smoke tests pass (25/27, 2 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)