### PR TITLE
test: update interferometer NNLS likelihoods for kappa=1e-11

### DIFF
--- a/scripts/jax_likelihood_functions/interferometer/mge_group.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge_group.py
@@ -120,7 +120,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -3154.742412,
+    -3154.194645,
     rtol=1e-4,
     err_msg="interferometer/mge_group: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/interferometer/rectangular.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular.py
@@ -263,7 +263,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -3164.77281,
+    -3164.286252,
     rtol=1e-4,
     err_msg="interferometer/rectangular: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/interferometer/simulator.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator.py
@@ -11,7 +11,7 @@ their likelihood values are deterministic and can be numerically asserted.
 
 __Dataset__
 
-The simulation uses the SMA uv_wavelengths stored in `dataset/interferometer/simple/uv_wavelengths.fits`
+The simulation uses the SMA uv_wavelengths stored in `dataset/interferometer/uv_wavelengths/sma.fits`
 (190 visibilities), giving fast and deterministic interferometer likelihood evaluations.
 
 __Model__
@@ -41,10 +41,10 @@ grid = al.Grid2D.uniform(shape_native=(256, 256), pixel_scales=0.1)
 """
 __UV Wavelengths__
 
-Load the SMA uv-coverage already stored in the dataset folder (190 baselines).
+Load the SMA uv-coverage stored in the repository's shared uv_wavelengths folder (190 baselines).
 """
 uv_wavelengths = al.ndarray_via_fits_from(
-    file_path=path.join(dataset_path, "uv_wavelengths.fits"), hdu=0
+    file_path=path.join("dataset", "interferometer", "uv_wavelengths", "sma.fits"), hdu=0
 )
 
 print(f"Total visibilities: {uv_wavelengths.shape[0]}")
@@ -99,6 +99,8 @@ __Output__
 
 Overwrite the dataset files in `dataset/interferometer/simple/`.
 """
+Path(dataset_path).mkdir(parents=True, exist_ok=True)
+
 import numpy as np
 
 al.output_to_fits(


### PR DESCRIPTION
## Summary
- Re-records expected interferometer log-likelihood in `rectangular.py` and `mge_group.py` to match the tighter `nnls_target_kappa=1.0e-11` default being introduced in PyAutoArray
- Points `simulator.py` at the shared `dataset/interferometer/uv_wavelengths/sma.fits` instead of a local-only uv coverage file

## Context
Depends on: https://github.com/PyAutoLabs/PyAutoArray/pull/283

With κ=1e-11 active, the 4 imaging likelihoods pass unchanged (exact / rel 1.2e-6), and `interferometer/mge.py` passes unchanged (rel 2.4e-6). Only interferometer rectangular-style inversions shift noticeably (~1.5e-4 relative), because that's where the NNLS primal solution is most sensitive to the central-path relaxation.

| Script | Old expected | New expected | Rel shift |
|---|---|---|---|
| `rectangular.py` | -3164.77281 | -3164.286252 | 1.54e-4 |
| `mge_group.py` | -3154.742412 | -3154.194645 | 1.74e-4 |

## Test plan
- [x] Run all 4 imaging scripts (`lp`, `mge`, `rectangular`, `delaunay`) on κ=1e-11 — all PASS
- [x] Run all 3 interferometer scripts (`mge`, `rectangular`, `mge_group`) on κ=1e-11 — all PASS with new expected values
- [ ] Merge PyAutoArray#283 first, then CI here

🤖 Generated with [Claude Code](https://claude.com/claude-code)