### PR TITLE
test(jax): mge_group_pytree.py — group-scale MGE jit(fit_from) regression

### DIFF
--- a/scripts/jax_likelihood_functions/imaging/mge_group_pytree.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group_pytree.py
@@ -1,0 +1,190 @@
+"""
+Path A PoC: jit-wrap ``analysis.fit_from`` for group-scale MGE
+==============================================================
+
+Sibling of ``mge_pytree.py`` for the group-scale lens path
+(see admin_jammy/prompt/issued/fit_imaging_pytree_mge_group.md). Main MGE lens
+at z=0.5 + 5 extra co-redshift galaxies (GaussianSph bulge + IsothermalSph mass)
++ MGE source at z=1.0.
+
+Success criterion:
+  - ``jax.jit(analysis.fit_from)(instance)`` returns a ``FitImaging`` whose
+    ``log_likelihood`` is a ``jax.Array`` matching the NumPy-path scalar.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autolens as al
+
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+
+
+"""
+__Dataset__ — same on-disk dataset used by ``mge_group.py``.
+"""
+dataset_path = path.join("dataset", "imaging", "jax_test")
+
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/imaging/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Imaging.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    psf_path=path.join(dataset_path, "psf.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    pixel_scales=0.2,
+)
+
+centre_list = [(0.0, 0.0), (0.0, 1.0), (0.0, 2.0), (0.0, 3.0), (0.0, 4.0)]
+
+mask = al.Mask2D.circular(
+    shape_native=dataset.shape_native, pixel_scales=dataset.pixel_scales, radius=4.0
+)
+dataset = dataset.apply_mask(mask=mask)
+
+over_sample_size = al.util.over_sample.over_sample_size_via_radial_bins_from(
+    grid=dataset.grid,
+    sub_size_list=[4, 2, 1],
+    radial_list=[0.3, 0.6],
+    centre_list=[(0.0, 0.0)] + centre_list,
+)
+dataset = dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
+
+
+"""
+__Model__ — main MGE lens + MGE source + 5 co-redshift extra galaxies.
+"""
+mask_radius = 3.0
+
+# Lens bulge: 30 Gaussians × 2 basis
+total_gaussians = 30
+gaussian_per_basis = 2
+log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+
+bulge_gaussian_list = []
+for j in range(gaussian_per_basis):
+    gaussian_list = af.Collection(
+        af.Model(al.lp_linear.Gaussian) for _ in range(total_gaussians)
+    )
+    for i, gaussian in enumerate(gaussian_list):
+        gaussian.centre.centre_0 = centre_0
+        gaussian.centre.centre_1 = centre_1
+        gaussian.ell_comps = gaussian_list[0].ell_comps
+        gaussian.sigma = 10 ** log10_sigma_list[i]
+    bulge_gaussian_list += gaussian_list
+
+bulge = af.Model(al.lp_basis.Basis, profile_list=bulge_gaussian_list)
+
+mass = af.Model(al.mp.Isothermal)
+shear = af.Model(al.mp.ExternalShear)
+
+lens = af.Model(al.Galaxy, redshift=0.5, bulge=bulge, mass=mass, shear=shear)
+
+# Source bulge: 30 Gaussians × 1 basis
+total_gaussians = 30
+gaussian_per_basis = 1
+centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+log10_sigma_list = np.linspace(-2, np.log10(1.0), total_gaussians)
+
+bulge_gaussian_list = []
+for j in range(gaussian_per_basis):
+    gaussian_list = af.Collection(
+        af.Model(al.lp_linear.Gaussian) for _ in range(total_gaussians)
+    )
+    for i, gaussian in enumerate(gaussian_list):
+        gaussian.centre.centre_0 = centre_0
+        gaussian.centre.centre_1 = centre_1
+        gaussian.ell_comps = gaussian_list[0].ell_comps
+        gaussian.sigma = 10 ** log10_sigma_list[i]
+    bulge_gaussian_list += gaussian_list
+
+source_bulge = af.Model(al.lp_basis.Basis, profile_list=bulge_gaussian_list)
+source = af.Model(al.Galaxy, redshift=1.0, bulge=source_bulge)
+
+# Extra galaxies: 5 × (GaussianSph basis + IsothermalSph at z=0.5)
+extra_galaxies_list = []
+
+for extra_galaxy_centre in centre_list:
+    total_gaussians = 10
+    log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+    gaussian_list = af.Collection(
+        af.Model(al.lp_linear.GaussianSph) for _ in range(total_gaussians)
+    )
+    for i, gaussian in enumerate(gaussian_list):
+        gaussian.centre.centre_0 = extra_galaxy_centre[0]
+        gaussian.centre.centre_1 = extra_galaxy_centre[1]
+        gaussian.sigma = 10 ** log10_sigma_list[i]
+
+    extra_galaxy_bulge = af.Model(
+        al.lp_basis.Basis, profile_list=list(gaussian_list)
+    )
+
+    extra_mass = af.Model(al.mp.IsothermalSph)
+    extra_mass.centre = extra_galaxy_centre
+    extra_mass.einstein_radius = af.UniformPrior(lower_limit=0.0, upper_limit=0.5)
+
+    extra_galaxy = af.Model(
+        al.Galaxy, redshift=0.5, bulge=extra_galaxy_bulge, mass=extra_mass
+    )
+    extra_galaxy.mass.centre = extra_galaxy_centre
+
+    extra_galaxies_list.append(extra_galaxy)
+
+extra_galaxies = af.Collection(extra_galaxies_list)
+
+model = af.Collection(
+    galaxies=af.Collection(lens=lens, source=source), extra_galaxies=extra_galaxies
+)
+
+
+"""
+__Analysis__ on the JAX path (``use_jax=True``).
+"""
+analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
+
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+
+"""
+__NumPy reference scalar__.
+"""
+analysis_np = al.AnalysisImaging(dataset=dataset, use_jax=False)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__.
+"""
+fit_jit_fn = jax.jit(analysis.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit type:", type(fit).__name__)
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")


### PR DESCRIPTION
## Summary

Adds `mge_group_pytree.py` covering the group-scale MGE lens path: main MGE lens + 5 co-redshift
extra galaxies (GaussianSph basis + IsothermalSph mass) + MGE source. NumPy and JIT log-likelihoods
agree to ~3e-11 (NumPy `-29018.536`, JIT `-29018.536`). **No new pytree registrations required** —
`Galaxies` container iteration and `Tracer` plane grouping for 7 galaxies round-trip cleanly under
`jax.jit`.

## Scripts Changed
- `scripts/jax_likelihood_functions/imaging/mge_group_pytree.py` (NEW) — Isothermal mass +
  ExternalShear + MGE basis lens, MGE basis source, 5 extra galaxies with GaussianSph bulges
  and IsothermalSph mass at the lens redshift; JIT-wrapped `analysis.fit_from` round-trip vs
  NumPy reference.

## Test Plan
- [x] Script prints `PASS: jit(fit_from) round-trip matches NumPy scalar.`
- [x] NumPy and JIT log-likelihoods agree to ~3e-11
- [x] No new library registrations needed

## Notes for sibling tasks

Confirms `Galaxies` and multi-galaxy plane grouping are pytree-clean out of the box. For
`fit_imaging_pytree_delaunay`, the `scipy.spatial.Delaunay` inside `MapperDelaunay` remains the
most likely first hit; multi-plane tasks should also be low-risk unless they expose cached
plane-index state.

Issue: https://github.com/PyAutoLabs/PyAutoLens/issues/452

🤖 Generated with [Claude Code](https://claude.com/claude-code)