### PR TITLE
Add Delaunay-pixelization jax.jit PoC

### DIFF
--- a/scripts/jax_likelihood_functions/imaging/delaunay_pytree.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_pytree.py
@@ -1,0 +1,190 @@
+"""
+Path A PoC: jit-wrap ``analysis.fit_from`` for Delaunay pixelization source
+===========================================================================
+
+Sibling of ``mge_pytree.py`` / ``rectangular_pytree.py`` for the Delaunay-
+pixelization source path (see admin_jammy/prompt/issued/fit_imaging_pytree_delaunay.md).
+Uses ``Hilbert`` image-mesh + ``al.mesh.Delaunay`` + ``al.reg.AdaptSplit``.
+
+Each run exposes the next unregistered type (likely ``MapperDelaunay`` /
+``image_mesh.Hilbert`` / ``scipy.spatial.Delaunay`` wrappers).
+
+Success criterion:
+  - ``jax.jit(analysis.fit_from)(instance)`` returns a ``FitImaging`` whose
+    ``log_likelihood`` is a ``jax.Array`` matching the NumPy-path scalar.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autolens as al
+
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+
+
+"""
+__Dataset__ — same on-disk dataset used by ``delaunay.py``.
+"""
+sub_size = 4
+
+dataset_path = path.join("dataset", "imaging", "jax_test")
+
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/imaging/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Imaging.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    psf_path=path.join(dataset_path, "psf.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    pixel_scales=0.2,
+    over_sample_size_lp=sub_size,
+    over_sample_size_pixelization=sub_size,
+)
+
+mask_radius = 2.6
+
+mask = al.Mask2D.circular(
+    shape_native=dataset.shape_native,
+    pixel_scales=dataset.pixel_scales,
+    radius=mask_radius,
+)
+dataset = dataset.apply_mask(mask=mask)
+
+over_sample_size = al.util.over_sample.over_sample_size_via_radial_bins_from(
+    grid=dataset.grid,
+    sub_size_list=[4, 2, 1],
+    radial_list=[0.3, 0.6],
+    centre_list=[(0.0, 0.0)],
+)
+dataset = dataset.apply_over_sampling(
+    over_sample_size_lp=over_sample_size,
+    over_sample_size_pixelization=1,
+)
+
+
+"""
+__Preloads__ — Delaunay needs static-shape image-plane mesh grid built from adapt image.
+"""
+pixels = 750
+edge_pixels_total = 30
+
+galaxy_image_name_dict = {
+    "('galaxies', 'lens')": dataset.data,
+    "('galaxies', 'source')": dataset.data,
+}
+
+image_mesh = al.image_mesh.Hilbert(pixels=pixels, weight_power=3.5, weight_floor=0.01)
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+    mask=dataset.mask, adapt_data=galaxy_image_name_dict["('galaxies', 'source')"]
+)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=mask.mask_centre,
+    radius=mask_radius + mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+total_mapper_pixels = image_plane_mesh_grid.shape[0]
+
+adapt_images = al.AdaptImages(
+    galaxy_name_image_dict=galaxy_image_name_dict,
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid
+    },
+)
+
+
+"""
+__Model__ — PowerLaw + ExternalShear lens, Delaunay pixelization source with AdaptSplit regularization.
+"""
+mass = af.Model(al.mp.PowerLaw)
+mass.centre.centre_0 = af.UniformPrior(lower_limit=0.2, upper_limit=0.4)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.4, upper_limit=-0.2)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+shear.gamma_2 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    mass=mass,
+    shear=shear,
+)
+
+regularization = al.reg.AdaptSplit()
+
+pixelization = af.Model(
+    al.Pixelization,
+    mesh=al.mesh.Delaunay(pixels=pixels, zeroed_pixels=edge_pixels_total),
+    regularization=regularization,
+)
+
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+
+"""
+__Analysis__ on the JAX path (``use_jax=True``).
+"""
+analysis = al.AnalysisImaging(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=True,
+)
+
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+
+"""
+__NumPy reference scalar__.
+"""
+analysis_np = al.AnalysisImaging(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__.
+"""
+fit_jit_fn = jax.jit(analysis.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit type:", type(fit).__name__)
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")


### PR DESCRIPTION
## Summary

- Adds ``scripts/jax_likelihood_functions/imaging/delaunay_pytree.py`` — sibling of
  ``mge_pytree.py`` / ``rectangular_pytree.py`` / ``mge_group_pytree.py`` that exercises
  ``jax.jit(analysis.fit_from)`` on a ``Delaunay`` pixelization source path.
- Asserts the JIT log_likelihood matches the NumPy reference to rtol 1e-4.

## Scripts Changed

- ``scripts/jax_likelihood_functions/imaging/delaunay_pytree.py`` — new PoC using
  ``al.image_mesh.Hilbert`` + ``al.mesh.Delaunay`` + ``al.reg.AdaptSplit``. Builds the
  image-plane mesh grid via ``Hilbert.image_plane_mesh_grid_from`` with edge-point
  padding, attaches it to ``AdaptImages``, constructs a PowerLaw + ExternalShear lens,
  and checks ``jax.jit`` round-trip against NumPy.

## Upstream PR

https://github.com/PyAutoLabs/PyAutoGalaxy/pull/361 — narrow ``GalaxiesToInversion``
fallback that unblocks the Delaunay path under ``jax.jit`` (identity-keyed dict
lookup after pytree unflatten). A follow-up prompt filed in ``admin_jammy/`` tracks
the principled ``Galaxy.pytree_token`` replacement.

## Test Plan

- [x] Script PASSes: NumPy and JIT log_likelihoods agree (rtol ~4e-15)
- [x] PyAutoGalaxy test suite unchanged (836 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)