### PR TITLE
feat: interferometer jax_likelihood parity + sparse variant

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -96,6 +96,12 @@ Scripts that test JAX can compute log-likelihood gradients and batch evaluations
 | `imaging/mge_group.py` | MGE with extra galaxies |
 | `interferometer/mge.py` | MGE for interferometry |
 | `interferometer/rectangular.py` | Rectangular pixelization for interferometry |
+| `interferometer/lp.py` | Parametric Sersic source for interferometry |
+| `interferometer/delaunay.py` | Delaunay pixelization for interferometry |
+| `interferometer/delaunay_mge.py` | Delaunay source + MGE lens for interferometry |
+| `interferometer/rectangular_mge.py` | Rectangular source + MGE lens for interferometry |
+| `interferometer/rectangular_dspl.py` | Rectangular source on double source plane (interferometry) |
+| `interferometer/rectangular_sparse.py` | Rectangular pixelization via JAX sparse-operator NUFFT path |
 | `point_source/point.py` | Point-source likelihood |
 
 ---

--- a/scripts/jax_likelihood_functions/interferometer/delaunay.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay.py
@@ -1,0 +1,274 @@
+"""
+Func Grad: Interferometer Delaunay Pixelization Source
+=======================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` dataset with a model which uses a Delaunay pixelization source.
+
+Mirrors `imaging/delaunay.py` but uses interferometer dataset loading and
+`AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load the interferometer dataset from .fits files.
+"""
+dataset_name = "simple"
+dataset_path = path.join("dataset", "interferometer", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+"""
+
+"""
+__JAX & Preloads__
+
+In JAX, calculations must use static shaped arrays with known and fixed indexes.
+For the Delaunay pixelization, we compute the image-plane mesh grid before modeling
+using the Hilbert image mesh, and append edge points to zero them.
+
+- `pixels`: number of source pixels in the Delaunay mesh.
+- `edge_pixels_total`: number of edge pixels zeroed in the source reconstruction.
+"""
+pixels = 750
+edge_pixels_total = 30
+
+# Use a Sersic image as adapt data (same as interferometer/rectangular.py) to avoid
+# negative values in the dirty image causing NaN in pixel signal computation.
+bulge_adapt = al.lp.Sersic()
+adapt_image = bulge_adapt.image_2d_from(grid=dataset.grid)
+
+galaxy_image_name_dict = {
+    "('galaxies', 'lens')": adapt_image,
+    "('galaxies', 'source')": adapt_image,
+}
+
+image_mesh = al.image_mesh.Hilbert(pixels=pixels, weight_power=3.5, weight_floor=0.01)
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+    mask=real_space_mask,
+    adapt_data=galaxy_image_name_dict["('galaxies', 'source')"],
+)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=real_space_mask.mask_centre,
+    radius=mask_radius + real_space_mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+total_mapper_pixels = image_plane_mesh_grid.shape[0]
+
+adapt_images = al.AdaptImages(
+    galaxy_name_image_dict=galaxy_image_name_dict,
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid
+    },
+)
+
+
+"""
+__Model__
+
+We compose our model using `Model` objects, which represent the galaxies we fit to
+our data. In this example we fit a model where:
+
+ - The lens galaxy has an `Isothermal` mass and `ExternalShear`.
+ - The source galaxy has a Delaunay pixelization.
+
+"""
+# Lens:
+
+mass = af.Model(al.mp.PowerLaw)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=0.2, upper_limit=0.4)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.4, upper_limit=-0.2)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+shear.gamma_2 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    mass=mass,
+    shear=shear,
+)
+
+# Source:
+
+regularization = al.reg.AdaptSplit()
+
+pixelization = af.Model(
+    al.Pixelization,
+    mesh=al.mesh.Delaunay(pixels=pixels, zeroed_pixels=edge_pixels_total),
+    regularization=regularization,
+)
+
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+
+This is the function on which JAX gradients are computed, so we create this class here.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+    batch_size=batch_size,
+)
+
+batch_size = fitness.batch_size
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -3165.42388511,
+    rtol=1e-4,
+    err_msg="interferometer/delaunay: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
@@ -1,0 +1,292 @@
+"""
+Func Grad: Interferometer Delaunay Source + MGE Lens Bulge
+===========================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` dataset with a model which uses an MGE lens bulge and
+Delaunay pixelization source.
+
+Mirrors `imaging/delaunay_mge.py` but uses interferometer dataset loading and
+`AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load the interferometer dataset from .fits files.
+"""
+dataset_name = "simple"
+dataset_path = path.join("dataset", "interferometer", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+"""
+
+"""
+__JAX & Preloads__
+
+Delaunay pixelization preloads: Hilbert image mesh and edge zeroed points.
+"""
+pixels = 750
+edge_pixels_total = 30
+
+# Use a Sersic image as adapt data (same as interferometer/rectangular.py) to avoid
+# negative values in the dirty image causing NaN in pixel signal computation.
+bulge_adapt = al.lp.Sersic()
+adapt_image = bulge_adapt.image_2d_from(grid=dataset.grid)
+
+galaxy_image_name_dict = {
+    "('galaxies', 'lens')": adapt_image,
+    "('galaxies', 'source')": adapt_image,
+}
+
+image_mesh = al.image_mesh.Hilbert(pixels=pixels, weight_power=3.5, weight_floor=0.01)
+
+image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+    mask=real_space_mask,
+    adapt_data=galaxy_image_name_dict["('galaxies', 'source')"],
+)
+
+image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+    image_plane_mesh_grid=image_plane_mesh_grid,
+    centre=real_space_mask.mask_centre,
+    radius=mask_radius + real_space_mask.pixel_scale / 2.0,
+    n_points=edge_pixels_total,
+)
+
+total_mapper_pixels = image_plane_mesh_grid.shape[0]
+
+adapt_images = al.AdaptImages(
+    galaxy_name_image_dict=galaxy_image_name_dict,
+    galaxy_name_image_plane_mesh_grid_dict={
+        "('galaxies', 'source')": image_plane_mesh_grid
+    },
+)
+
+
+"""
+__Model__
+
+We compose our model using `Model` objects, which represent the galaxies we fit to
+our data. In this example we fit a model where:
+
+ - The lens galaxy has an MGE bulge, `Isothermal` mass and `ExternalShear`.
+ - The source galaxy has a Delaunay pixelization.
+"""
+# Lens:
+
+bulge = al.model_util.mge_model_from(
+    mask_radius=mask_radius,
+    total_gaussians=30,
+    gaussian_per_basis=2,
+    centre_prior_is_uniform=True,
+)
+
+mass = af.Model(al.mp.Isothermal)
+
+shear = af.Model(al.mp.ExternalShear)
+
+lens = af.Model(al.Galaxy, redshift=0.5, bulge=bulge, mass=mass, shear=shear)
+
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=0.000, upper_limit=0.002)
+shear.gamma_2 = af.UniformPrior(lower_limit=0.000, upper_limit=0.002)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    bulge=bulge,
+    mass=mass,
+    shear=shear,
+)
+
+# Source:
+
+pixelization = af.Model(
+    al.Pixelization,
+    mesh=al.mesh.Delaunay(pixels=pixels, zeroed_pixels=edge_pixels_total),
+    regularization=al.reg.MaternAdaptKernel,
+)
+
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=False,
+        use_mixed_precision=True,
+    ),
+    use_jax=True,
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 1
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -3155.2691936,
+    rtol=1e-4,
+    err_msg="interferometer/delaunay_mge: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=False,
+        use_mixed_precision=True,
+    ),
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=False,
+        use_mixed_precision=True,
+    ),
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/lp.py
+++ b/scripts/jax_likelihood_functions/interferometer/lp.py
@@ -1,0 +1,219 @@
+"""
+Func Grad: Interferometer Parametric Sersic Source
+====================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` dataset with a model which uses a parametric Sersic source.
+
+Mirrors `imaging/lp.py` but uses interferometer dataset loading (real_space_mask,
+Interferometer.from_fits, TransformerDFT) from `interferometer/rectangular.py`.
+No apply_over_sampling — interferometer does not oversample.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load the interferometer dataset from .fits files.
+"""
+dataset_name = "simple"
+dataset_path = path.join("dataset", "interferometer", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script. This ensures that all example scripts can be run
+without manually simulating data first.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Positions__
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=path.join(dataset_path, "positions.json"))
+)
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+"""
+
+"""
+__Model__
+
+We compose our model using `Model` objects, which represent the galaxies we fit to
+our data. In this example we fit a model where:
+
+ - The lens galaxy has an `Isothermal` mass and `ExternalShear`.
+ - The source galaxy has a parametric `Sersic` light profile via `lp_linear.Sersic`.
+
+The number of free parameters and therefore the dimensionality of non-linear parameter
+space is N=12.
+"""
+# Lens:
+
+bulge = af.Model(al.lp_linear.Sersic)
+
+mass = af.Model(al.mp.PowerLaw)
+
+shear = af.Model(al.mp.ExternalShear)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    bulge=bulge,
+    mass=mass,
+    shear=shear,
+)
+
+# Source:
+
+bulge = af.Model(al.lp_linear.Sersic)
+
+source = af.Model(al.Galaxy, redshift=1.0, bulge=bulge)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    positions_likelihood_list=[al.PositionsLH(threshold=0.4, positions=positions)],
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+
+This is the function on which JAX gradients are computed, so we create this class here.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 1
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -1.16915394e09,
+    rtol=1e-4,
+    err_msg="interferometer/lp: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    positions_likelihood_list=[al.PositionsLH(threshold=0.4, positions=positions)],
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    positions_likelihood_list=[al.PositionsLH(threshold=0.4, positions=positions)],
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
@@ -1,0 +1,266 @@
+"""
+Func Grad: Interferometer Rectangular Pixelization Double Source Plane
+=======================================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` double source plane (DSPL) dataset with a model which uses
+rectangular pixelization sources at two redshifts.
+
+Mirrors `imaging/rectangular_dspl.py` but loads from `dataset/interferometer/dspl/`
+via `Interferometer.from_fits` and uses `AnalysisInterferometer`. No
+apply_over_sampling — interferometer does not oversample.
+
+The `should_simulate` bootstrap invokes `simulator_dspl.py` to generate the dataset.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load the interferometer DSPL dataset from .fits files.
+"""
+dataset_path = path.join("dataset", "interferometer", "dspl")
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator_dspl.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+
+__Mesh Shape__
+"""
+image_mesh = None
+mesh_shape = (30, 30)
+total_mapper_pixels = mesh_shape[0] * mesh_shape[1]
+
+"""
+__Model__
+
+Three-galaxy double source plane system:
+ - lens_0 at z=0.5: MGE bulge, `Isothermal` mass, `ExternalShear`.
+ - lens_1 at z=1.0: `Isothermal` mass, rectangular pixelization (intermediate source).
+ - source at z=2.0: rectangular pixelization.
+"""
+# Lens 0 (z=0.5):
+
+bulge = al.model_util.mge_model_from(
+    mask_radius=mask_radius,
+    total_gaussians=30,
+    gaussian_per_basis=2,
+    centre_prior_is_uniform=True,
+)
+
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.2, upper_limit=0.2)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.2, upper_limit=0.2)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+shear.gamma_2 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+
+lens_0 = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    bulge=bulge,
+    mass=mass,
+    shear=shear,
+)
+
+# Lens 1 (z=1.0) with intermediate rectangular pixelization:
+
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.2, upper_limit=0.2)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.2, upper_limit=0.2)
+mass.einstein_radius = af.UniformPrior(lower_limit=0.4, upper_limit=0.6)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+mesh = al.mesh.RectangularAdaptImage(shape=mesh_shape, weight_power=1.0)
+
+regularization = al.reg.Adapt()
+
+pixelization = al.Pixelization(mesh=mesh, regularization=regularization)
+
+lens_1 = af.Model(al.Galaxy, redshift=1.0, mass=mass, pixelization=pixelization)
+
+# Source (z=2.0):
+
+mesh = al.mesh.RectangularAdaptImage(shape=mesh_shape, weight_power=1.0)
+
+regularization = al.reg.Adapt()
+
+pixelization = al.Pixelization(mesh=mesh, regularization=regularization)
+
+source = af.Model(al.Galaxy, redshift=2.0, pixelization=pixelization)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens_0, lens_1=lens_1, source=source))
+
+# Use a Sersic image as adapt data to avoid negative dirty-image values.
+bulge_adapt = al.lp.Sersic()
+adapt_image = bulge_adapt.image_2d_from(grid=dataset.grid)
+
+galaxy_name_image_dict = {
+    "('galaxies', 'lens_0')": adapt_image,
+    "('galaxies', 'lens_1')": adapt_image,
+    "('galaxies', 'source')": adapt_image,
+}
+
+adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_name_image_dict)
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 1
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -3170.6680826,
+    rtol=1e-4,
+    err_msg="interferometer/rectangular_dspl: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
@@ -1,0 +1,276 @@
+"""
+Func Grad: Interferometer Rectangular Source + MGE Lens Bulge
+==============================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` dataset with a model which uses an MGE lens bulge and
+rectangular pixelization source.
+
+Mirrors `imaging/rectangular_mge.py` but uses interferometer dataset loading and
+`AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load the interferometer dataset from .fits files.
+"""
+dataset_name = "simple"
+dataset_path = path.join("dataset", "interferometer", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+"""
+
+"""
+__Mesh Shape__
+
+The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to
+reconstruct the source, set below to 28 x 28.
+
+The `mesh_shape` must be fixed before modeling and cannot be a free parameter of
+the model.
+"""
+mesh_pixels_yx = 28
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+# Use a Sersic image as adapt data (same as interferometer/rectangular.py) to avoid
+# negative values in the dirty image causing NaN in pixel signal computation.
+bulge_adapt = al.lp.Sersic()
+adapt_image = bulge_adapt.image_2d_from(grid=dataset.grid)
+
+galaxy_image_name_dict = {
+    "('galaxies', 'lens')": adapt_image,
+    "('galaxies', 'source')": adapt_image,
+}
+
+adapt_images = al.AdaptImages(
+    galaxy_name_image_dict=galaxy_image_name_dict,
+)
+
+"""
+__Model__
+
+We compose our model using `Model` objects, which represent the galaxies we fit to
+our data. In this example we fit a model where:
+
+ - The lens galaxy has an MGE bulge, `Isothermal` mass and `ExternalShear`.
+ - The source galaxy has a rectangular pixelization.
+"""
+# Lens:
+
+bulge = al.model_util.mge_model_from(
+    mask_radius=mask_radius,
+    total_gaussians=30,
+    gaussian_per_basis=2,
+    centre_prior_is_uniform=True,
+)
+
+mass = af.Model(al.mp.Isothermal)
+
+shear = af.Model(al.mp.ExternalShear)
+
+lens = af.Model(al.Galaxy, redshift=0.5, bulge=bulge, mass=mass, shear=shear)
+
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=0.000, upper_limit=0.002)
+shear.gamma_2 = af.UniformPrior(lower_limit=0.000, upper_limit=0.002)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    bulge=bulge,
+    mass=mass,
+    shear=shear,
+)
+
+# Source:
+
+mesh = al.mesh.RectangularAdaptImage(shape=mesh_shape)
+
+regularization = al.reg.Constant()
+
+pixelization = al.Pixelization(mesh=mesh, regularization=regularization)
+
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=True,
+        use_mixed_precision=True,
+    ),
+    adapt_images=adapt_images,
+    use_jax=True,
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 6
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -3162.38741934,
+    rtol=1e-4,
+    err_msg="interferometer/rectangular_mge: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=True,
+        use_mixed_precision=True,
+    ),
+    adapt_images=adapt_images,
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=True,
+        use_mixed_precision=True,
+    ),
+    adapt_images=adapt_images,
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
@@ -1,0 +1,257 @@
+"""
+Func Grad: Interferometer Rectangular Pixelization via JAX Sparse NUFFT Operator
+==================================================================================
+
+This script tests if JAX can successfully compute the gradient of the log likelihood
+of an `Interferometer` dataset using the JAX sparse-operator NUFFT path.
+
+This is a copy of `interferometer/rectangular.py` with one additional line after
+`Interferometer.from_fits(...)`:
+
+    dataset = dataset.apply_sparse_operator(use_jax=True, show_progress=True)
+
+The sparse NUFFT operator is aux state and must NOT be constructed inside the JIT
+trace. It is built once before analysis construction and carried as static state.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+from autoconf import conf
+
+"""
+__Mask__
+
+We define the 'real_space_mask' which defines the grid the image the strong lens is
+evaluated using.
+"""
+mask_radius = 3.0
+
+real_space_mask = al.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=mask_radius,
+)
+
+"""
+__Dataset__
+
+Load and plot the galaxy dataset `operated` via .fits files, which we will fit with
+the model.
+"""
+dataset_name = "simple"
+dataset_path = path.join("dataset", "interferometer", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running
+the corresponding simulator script.
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+dataset = al.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=al.TransformerDFT,
+)
+
+"""
+__Sparse Operator__
+
+Apply the JAX sparse NUFFT operator. This builds the sparse operator once as aux
+state — it must NOT be constructed inside the JIT trace.
+"""
+dataset = dataset.apply_sparse_operator(use_jax=True, show_progress=True)
+
+print(f"Total Visiblities: {dataset.uv_wavelengths.shape[0]}")
+
+"""
+__Positions__
+"""
+positions = al.Grid2DIrregular(
+    al.from_json(file_path=path.join(dataset_path, "positions.json"))
+)
+
+"""
+__Over Sampling__
+
+Interferometer does not observe galaxies in a way where over sampling is necessary,
+therefore all interferometer calculations are performed without over sampling.
+
+__Mesh Shape__
+
+The `mesh_shape` parameter defines number of pixels used by the rectangular mesh to
+reconstruct the source, set below to 8 x 8.
+"""
+mesh_pixels_yx = 8
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+"""
+__Model__
+
+We compose our model using `Model` objects, which represent the galaxies we fit to
+our data.
+"""
+# Lens:
+
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.7)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(
+    lower_limit=0.11111111111111108, upper_limit=0.1111111111111111
+)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.01, upper_limit=0.01)
+
+shear = af.Model(al.mp.ExternalShear)
+shear.gamma_1 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+shear.gamma_2 = af.UniformPrior(lower_limit=-0.001, upper_limit=0.001)
+
+lens = af.Model(
+    al.Galaxy,
+    redshift=0.5,
+    mass=mass,
+    shear=shear,
+)
+
+# Source:
+
+mesh = al.mesh.RectangularAdaptDensity(shape=mesh_shape)
+
+regularization = al.reg.Adapt()
+
+pixelization = al.Pixelization(mesh=mesh, regularization=regularization)
+
+source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+# Overall Lens Model:
+
+model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+
+bulge = al.lp.Sersic()
+
+image = bulge.image_2d_from(grid=dataset.grid)
+
+galaxy_name_image_dict = {
+    "('galaxies', 'lens')": image,
+    "('galaxies', 'source')": image,
+}
+
+
+adapt_images = al.AdaptImages(galaxy_name_image_dict=galaxy_name_image_dict)
+
+"""
+The `info` attribute shows the model in a readable format.
+"""
+print(model.info)
+
+"""
+__Analysis__
+
+The `AnalysisInterferometer` object defines the `log_likelihood_function` which will
+be used to determine if JAX can compute its gradient.
+"""
+analysis = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+)
+
+"""
+The analysis and `log_likelihood_function` are internally wrapped into a `Fitness`
+class in **PyAutoFit**, which pairs the model with likelihood.
+"""
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 1
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+
+parameters = jnp.array(parameters)
+
+start = time.time()
+print()
+print(fitness._vmap(parameters))
+print("JAX Time To VMAP + JIT Function", time.time() - start)
+
+start = time.time()
+print()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+np.testing.assert_allclose(
+    np.array(result),
+    -3152.03184792,
+    rtol=1e-4,
+    err_msg="interferometer/rectangular_sparse: JAX vmap likelihood mismatch",
+)
+
+
+"""
+__Path A: jit-wrap ``analysis.fit_from``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+instance = model.instance_from_prior_medians()
+
+analysis_np = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=False,
+)
+fit_np = analysis_np.fit_from(instance=instance)
+print("NumPy fit.log_likelihood:", float(fit_np.log_likelihood))
+
+analysis_jit = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=True,
+)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), (
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+)
+np.testing.assert_allclose(
+    float(fit.log_likelihood), float(fit_np.log_likelihood), rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
@@ -1,0 +1,171 @@
+"""
+Simulator: Interferometer Double Source Plane
+=============================================
+
+This script simulates an `Interferometer` dataset of a strong gravitational lens
+with two source planes (double source plane, DSPL) used by the JAX likelihood
+function tests in this folder.
+
+It saves the dataset to `dataset/interferometer/dspl/`, overwriting existing files.
+The `rectangular_dspl.py` JAX test loads from this fixed dataset so that its
+likelihood values are deterministic and can be numerically asserted.
+
+Mirrors `imaging/simulator_dspl.py` but uses `SimulatorInterferometer` and writes
+the interferometer file layout (data.fits with real+imag stacked, noise_map.fits
+with real+imag stacked, uv_wavelengths.fits, positions.json).
+
+__Dataset__
+
+The simulation uses the SMA uv_wavelengths stored in
+`dataset/interferometer/uv_wavelengths/sma.fits` (190 visibilities).
+
+__Model__
+
+ - Lens 0 at z=0.5: `Sersic` bulge + disk, `Isothermal` mass + `ExternalShear`.
+ - Lens 1 at z=1.0: `Isothermal` mass (acts as intermediate lens for source).
+ - Source at z=2.0: `SersicCore` light profile.
+
+The redshifts match `imaging/simulator_dspl.py`.
+"""
+
+from os import path
+from pathlib import Path
+import numpy as np
+import autolens as al
+
+dataset_type = "interferometer"
+dataset_name = "dspl"
+
+dataset_path = path.join("dataset", dataset_type, dataset_name)
+
+"""
+__Grid__
+
+Real-space grid on which the lens image is evaluated before Fourier transforming.
+"""
+grid = al.Grid2D.uniform(shape_native=(256, 256), pixel_scales=0.1)
+
+"""
+__UV Wavelengths__
+
+Load the SMA uv-coverage stored in the repository's shared uv_wavelengths folder.
+"""
+uv_wavelengths = al.ndarray_via_fits_from(
+    file_path=path.join("dataset", "interferometer", "uv_wavelengths", "sma.fits"),
+    hdu=0,
+)
+
+print(f"Total visibilities: {uv_wavelengths.shape[0]}")
+
+"""
+__Simulator__
+"""
+simulator = al.SimulatorInterferometer(
+    uv_wavelengths=uv_wavelengths,
+    exposure_time=300.0,
+    noise_sigma=1000.0,
+    transformer_class=al.TransformerDFT,
+    noise_seed=1,
+)
+
+"""
+__Ray Tracing__
+
+Three-galaxy system: two lenses + one source (double source plane).
+Redshifts mirror `imaging/simulator_dspl.py`.
+"""
+lens_galaxy = al.Galaxy(
+    redshift=0.5,
+    bulge=al.lp.Sersic(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+        intensity=4.0,
+        effective_radius=0.6,
+        sersic_index=3.0,
+    ),
+    disk=al.lp.Exponential(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.7, angle=30.0),
+        intensity=2.0,
+        effective_radius=1.6,
+    ),
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=1.6,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+    ),
+    shear=al.mp.ExternalShear(gamma_1=0.0, gamma_2=0.0),
+)
+
+lens_galaxy_1 = al.Galaxy(
+    redshift=1.0,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=0.5,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+    ),
+)
+
+source_galaxy = al.Galaxy(
+    redshift=2.0,
+    bulge=al.lp.SersicCore(
+        centre=(0.1, 0.1),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.8, angle=60.0),
+        intensity=0.3,
+        effective_radius=1.0,
+        sersic_index=1.0,
+    ),
+)
+
+tracer = al.Tracer(galaxies=[lens_galaxy, lens_galaxy_1, source_galaxy])
+
+"""
+__Simulate__
+"""
+dataset = simulator.via_tracer_from(tracer=tracer, grid=grid)
+
+"""
+__Output__
+
+Write the dataset to `dataset/interferometer/dspl/` using the interferometer file
+layout: data.fits (real+imag stacked), noise_map.fits (real+imag stacked),
+uv_wavelengths.fits, positions.json.
+"""
+Path(dataset_path).mkdir(parents=True, exist_ok=True)
+
+al.output_to_fits(
+    values=np.stack([dataset.data.real, dataset.data.imag], axis=-1),
+    file_path=path.join(dataset_path, "data.fits"),
+    overwrite=True,
+)
+al.output_to_fits(
+    values=np.stack([dataset.noise_map.real, dataset.noise_map.imag], axis=-1),
+    file_path=path.join(dataset_path, "noise_map.fits"),
+    overwrite=True,
+)
+al.output_to_fits(
+    values=dataset.uv_wavelengths,
+    file_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    overwrite=True,
+)
+
+"""
+__Multiple Image Positions__
+
+Compute and save the multiple-image positions from the source at z=2.0.
+"""
+solver = al.PointSolver.for_grid(
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
+)
+
+positions = solver.solve(
+    tracer=tracer, source_plane_coordinate=source_galaxy.bulge.centre
+)
+
+al.output_to_json(
+    file_path=path.join(dataset_path, "positions.json"),
+    obj=positions,
+)
+
+print(f"Saved {len(positions)} multiple-image positions to positions.json")
+print("Dataset written to", dataset_path)


### PR DESCRIPTION
## Summary

Extend `scripts/jax_likelihood_functions/interferometer/` from 4 to 11 variants, bringing coverage to parity with the imaging sibling. Adds one new pixelization variant exercising the JAX sparse-operator NUFFT path (`dataset.apply_sparse_operator(use_jax=True, show_progress=True)`) used in the `autolens_workspace` notebooks but not previously covered by the integration test suite.

## Scripts Changed

- `scripts/jax_likelihood_functions/interferometer/lp.py` — parametric Sersic source (new)
- `scripts/jax_likelihood_functions/interferometer/delaunay.py` — Delaunay pixelization with Hilbert image-mesh (new)
- `scripts/jax_likelihood_functions/interferometer/delaunay_mge.py` — Delaunay source + MGE lens (new)
- `scripts/jax_likelihood_functions/interferometer/rectangular_mge.py` — Rectangular source + MGE lens (new)
- `scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py` — Rectangular source on double source plane (new)
- `scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py` — Rectangular pixelization via JAX sparse-operator NUFFT path (new)
- `scripts/jax_likelihood_functions/interferometer/simulator_dspl.py` — Double source plane interferometer simulator (new)
- `scripts/CLAUDE.md` — extend jax_likelihood_functions table with 6 new rows

## Test Plan

- [ ] Smoke tests pass for autolens_workspace_test

Each new script follows the established three-step pattern:
1. \`fitness._vmap(parameters)\` with hardcoded expected log-likelihood (rtol=1e-4)
2. NumPy-path \`analysis.fit_from\` reference
3. Path A \`jax.jit(analysis.fit_from)\` round-trip matching NumPy within rtol=1e-4

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)