### PR TITLE
refactor(jax_likelihood_functions): drop xp=jnp from PointSolver.for_grid

### DIFF
--- a/scripts/jax_likelihood_functions/point_source/image_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/image_plane.py
@@ -61,7 +61,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -104,7 +104,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """

--- a/scripts/jax_likelihood_functions/point_source/source_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/source_plane.py
@@ -72,7 +72,7 @@ grid = al.Grid2D.uniform(
 )
 
 solver = al.PointSolver.for_grid(
-    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1, xp=jnp
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
 )
 
 """


### PR DESCRIPTION
## Summary

Updates the 3 point-source JAX-likelihood verification scripts to use the new `PointSolver.for_grid` signature from PyAutoLabs/PyAutoLens#469. The cross-xp assertions (numpy vs JAX via `AnalysisPoint(use_jax=True)`) are retained and continue to match (log-likelihood `1.31350833` for `image_plane` and `point`; `-199.155585` for `source_plane`).

## Scripts Changed
- `scripts/jax_likelihood_functions/point_source/image_plane.py` — drop `xp=jnp` from `PointSolver.for_grid`
- `scripts/jax_likelihood_functions/point_source/point.py` — drop `xp=jnp` from `PointSolver.for_grid`
- `scripts/jax_likelihood_functions/point_source/source_plane.py` — drop `xp=jnp` from `PointSolver.for_grid`

## Upstream PR
https://github.com/PyAutoLabs/PyAutoLens/pull/469

## Test Plan
- [ ] All 3 scripts run end-to-end (already verified in upstream session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)