### PR TITLE
Align db/scrape scripts with simulator build/ dataset path

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -17,6 +17,7 @@
 #   banner. Investigate the failure, fix the underlying bug, and remove
 #   the NEEDS_FIX marker.
 
+- database/scrape/general # NEEDS_FIX 2026-04-27 - PyAutoGalaxy abstract_fit.linear_light_profile_intensity_dict raises "TypeError: __hash__ method should return an integer" during subplot_fit_imaging after the search completes (a light-profile object's __hash__ returns a non-int). Surfaced once the dataset_label="build" path fix let the script progress past Imaging.from_fits.
 - database/scrape/multi_analysis # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_general # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode

--- a/scripts/database/scrape/general.py
+++ b/scripts/database/scrape/general.py
@@ -23,8 +23,9 @@ import autolens.plot as aplt
 """
 __Dataset + Masking__
 """
+dataset_label = "build"
 dataset_name = "no_lens_light"
-dataset_path = path.join("dataset", "imaging", dataset_name)
+dataset_path = path.join("dataset", dataset_label, "imaging", dataset_name)
 
 """
 __Dataset Auto-Simulation__

--- a/scripts/database/scrape/scaling_relation.py
+++ b/scripts/database/scrape/scaling_relation.py
@@ -48,8 +48,9 @@ import autolens.plot as aplt
 """
 __Dataset + Masking__
 """
+dataset_label = "build"
 dataset_name = "no_lens_light"
-dataset_path = path.join("dataset", "imaging", dataset_name)
+dataset_path = path.join("dataset", dataset_label, "imaging", dataset_name)
 
 """
 __Dataset Auto-Simulation__

--- a/scripts/database/scrape/slam_general.py
+++ b/scripts/database/scrape/slam_general.py
@@ -298,8 +298,9 @@ def fit():
     """
     __Dataset + Masking__
     """
+    dataset_label = "build"
     dataset_name = "with_lens_light"
-    dataset_path = path.join("dataset", "imaging", dataset_name)
+    dataset_path = path.join("dataset", dataset_label, "imaging", dataset_name)
 
     if not path.exists(dataset_path):
         import subprocess

--- a/scripts/database/scrape/slam_pix.py
+++ b/scripts/database/scrape/slam_pix.py
@@ -311,8 +311,9 @@ def fit():
     """
     __Dataset + Masking__
     """
+    dataset_label = "build"
     dataset_name = "with_lens_light"
-    dataset_path = path.join("dataset", "imaging", dataset_name)
+    dataset_path = path.join("dataset", dataset_label, "imaging", dataset_name)
 
     if not path.exists(dataset_path):
         import subprocess


### PR DESCRIPTION
## Summary
The 4 `database/scrape` consumer scripts in this workspace loaded `dataset/imaging/no_lens_light/` (and `dataset/imaging/with_lens_light/`), but the corresponding simulator scripts under `scripts/imaging/simulator/` write to `dataset/build/imaging/<name>/` — the `dataset_label = "build"` convention shared by every other non-database script here (`model_fit.py`, `convolution.py`, `point_source/simulators/point_source.py`).

The result: each consumer's auto-simulation subprocess "succeeded" while writing to a folder the consumer never reads, and the consumer then crashed on the next `Imaging.from_fits` call with `FileNotFoundError`. Surfaced by `/health_check` on 2026-04-27.

## Scripts Changed
- `scripts/database/scrape/general.py` — added `dataset_label = "build"` and used it in `dataset_path` so the auto-sim output is found.
- `scripts/database/scrape/scaling_relation.py` — same.
- `scripts/database/scrape/slam_general.py` — same.
- `scripts/database/scrape/slam_pix.py` — same.
- `config/build/no_run.yaml` — added `database/scrape/general` with a `NEEDS_FIX 2026-04-27` marker. The dataset-path fix unmasks a deeper, pre-existing PyAutoGalaxy bug: `abstract_fit.linear_light_profile_intensity_dict` raises `TypeError: __hash__ method should return an integer` during `subplot_fit_imaging` after the search completes. Park here until the library bug is fixed; remove the entry to re-enable.

## Test Plan
- [x] Smoke pass for `autolens_workspace_test` (12/12 with `database/scrape/general` skipped via `no_run.yaml`).
- [x] `general.py` verified manually to progress past `Imaging.from_fits` and through the full Nautilus search before hitting the parked PyAutoGalaxy `__hash__` bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)