### PR TITLE
chore: ignore generated artifacts and untrack stale ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ test_results/
 root.log
 **/images/
 /Users/Jammy/Code/PyAutoLabs/autolens_workspace/howtolens/config
+
+# Generated artifacts — never check in
+image.fits
+path/
+scripts/path/
+scripts/scripts/
+output_path/
+*.log
+*.pyc
+.codex/


### PR DESCRIPTION
## Summary
Append prompt 02's missing `.gitignore` patterns (deduped against existing) and `git rm --cached` 0 tracked files matching the new patterns. One of 8 PRs implementing PyAutoLabs/PyAutoPrompt#6 (workspace-gitignore-noise umbrella).

## Test Plan
- [ ] `git status` is clean after pulling this PR onto a fresh checkout.
- [ ] Tracked files that match the new patterns no longer appear in `git ls-files`.
- [ ] Datasets and other intentionally-tracked content under `dataset/`, `scripts/`, etc. remain tracked.

<details>
<summary>Patterns appended (only those missing from this repo's existing .gitignore)</summary>

```
image.fits
path/
scripts/path/
scripts/scripts/
output_path/
*.log
*.pyc
.codex/
```

</details>

<details>
<summary>Files removed from tracking via git rm --cached (0)</summary>

None — no tracked files in this repo matched the new patterns.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)