### PR TITLE
fix: regenerate stale jax_likelihood_functions literals after Poisson sign fix

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -17,9 +17,13 @@ This workspace is often imported from `/mnt/c/...` and Codex may not be able to 
 
 - Scripts run **without** `PYAUTOFIT_TEST_MODE=1` — non-linear searches execute for
   real (using sampler limits like `n_like_max=300` to keep runtime short).
-- No hardcoded expected numerical values in pure-logic or JAX tests.  Assertions
-  are relational (e.g. "JAX result matches NumPy result", "deflected grid ≠ input
-  grid") so they remain valid across profile parameter changes.
+- `jax_likelihood_functions/` scripts assert their `fitness._vmap` output against a
+  hardcoded expected log-likelihood literal (`assert_allclose(np.array(result), <value>, rtol=1e-4)`).
+  These literals are regression markers for the simulator + likelihood pipeline as a
+  whole; if a deliberate simulator change shifts the value, regenerate the literal
+  by running the script and pasting in the new `result` value. Don't replace these
+  with relational `vmap ≈ NumPy-path` assertions — that would lose absolute regression
+  detection.
 - JAX tests follow the **three-step pattern** established in `hessian_jax.py`:
   1. NumPy path — assert correct autoarray return type with `np.ndarray` backing.
   2. JAX path outside JIT — assert same autoarray type but with `jax.Array` backing.

--- a/scripts/jax_likelihood_functions/imaging/delaunay.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay.py
@@ -289,7 +289,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -23662.848904,
+    -22205.87818084,
     rtol=1e-4,
     err_msg="delaunay: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
@@ -309,7 +309,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -536.770444,
+    -560.01194096,
     rtol=1e-4,
     err_msg="delaunay_mge: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/imaging/mge_group.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group.py
@@ -305,7 +305,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -29018.535715,
+    -29060.21511937,
     rtol=1e-4,
     err_msg="mge_group: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/imaging/rectangular.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular.py
@@ -259,7 +259,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -650633.057031,
+    -651692.99779861,
     rtol=1e-4,
     err_msg="rectangular: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
@@ -274,7 +274,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    1134.94493,
+    1170.07439094,
     rtol=1e-4,
     err_msg="rectangular_dspl: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
@@ -297,7 +297,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -111.368202,
+    -82.94939477,
     rtol=1e-4,
     err_msg="rectangular_mge: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/multi/delaunay.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay.py
@@ -202,7 +202,7 @@ print(result)
 print("JAX Time Taken using VMAP:", time.time() - start)
 print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
-EXPECTED_VMAP_LOG_LIKELIHOOD = -6352.67199073
+EXPECTED_VMAP_LOG_LIKELIHOOD = -8853.0665931
 
 np.testing.assert_allclose(
     np.array(result),

--- a/scripts/jax_likelihood_functions/multi/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay_mge.py
@@ -200,7 +200,7 @@ print(result)
 print("JAX Time Taken using VMAP:", time.time() - start)
 print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
-EXPECTED_VMAP_LOG_LIKELIHOOD = -124.32724392
+EXPECTED_VMAP_LOG_LIKELIHOOD = -545.25327979
 
 np.testing.assert_allclose(
     np.array(result),

--- a/scripts/jax_likelihood_functions/multi/mge.py
+++ b/scripts/jax_likelihood_functions/multi/mge.py
@@ -149,7 +149,7 @@ print(result)
 print("JAX Time Taken using VMAP:", time.time() - start)
 print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
-EXPECTED_VMAP_LOG_LIKELIHOOD = -2174335.96508048
+EXPECTED_VMAP_LOG_LIKELIHOOD = -2173221.43685875
 
 np.testing.assert_allclose(
     np.array(result),

--- a/scripts/jax_likelihood_functions/multi/rectangular.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular.py
@@ -198,7 +198,7 @@ print(result)
 print("JAX Time Taken using VMAP:", time.time() - start)
 print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
-EXPECTED_VMAP_LOG_LIKELIHOOD = -12670.19450898
+EXPECTED_VMAP_LOG_LIKELIHOOD = -12928.70087095
 
 np.testing.assert_allclose(
     np.array(result),

--- a/scripts/jax_likelihood_functions/multi/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular_mge.py
@@ -183,7 +183,7 @@ print(result)
 print("JAX Time Taken using VMAP:", time.time() - start)
 print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
-EXPECTED_VMAP_LOG_LIKELIHOOD = -6093.81344693
+EXPECTED_VMAP_LOG_LIKELIHOOD = -6146.59211318
 
 np.testing.assert_allclose(
     np.array(result),


### PR DESCRIPTION
## Summary
- Regenerate **11 hardcoded log-likelihood literals** in `scripts/jax_likelihood_functions/` (4 imaging-failed, 5 multi-failed, 2 imaging-borderline) to match current simulator output.
- Update `scripts/CLAUDE.md` testing-philosophy: hardcoded literals are the intentional regression markers, with a one-line regeneration recipe.

## Why
The 2026-04-29 release-prep run flagged 9 failing scripts. Root cause: PyAutoArray commit `be3a3a2f` corrected the sign in `preprocess.poisson_noise_via_data_eps_from`. Because `dataset/` is gitignored, every fresh checkout re-simulates with the post-fix sign and gets noise maps that drift pixelization-driven likelihoods past `rtol=1e-4`. The recorded literals were captured pre-fix and are stale.

Two additional imaging scripts (`delaunay_mge`, `mge_group`) — which passed in the release-prep run by ~1e-4 margins — also drifted past tolerance in re-verification. Regenerated alongside the failing 9.

The trade-off considered: convert vmap assertions to relational (`vmap ≈ NumPy-path`) to immunise the suite from future simulator changes. **Explicitly rejected** — relational form would lose absolute regression detection on the NumPy path itself. Hardcoded literals are kept as the intentional regression markers; when a deliberate simulator change shifts the value, regenerate.

## API Changes
None.

## Scripts Changed

| Script | Old literal | New literal |
|---|---|---|
| imaging/delaunay.py | `-23662.848904` | `-22205.87818084` |
| imaging/delaunay_mge.py | `-536.770444` | `-560.01194096` |
| imaging/mge_group.py | `-29018.535715` | `-29060.21511937` |
| imaging/rectangular.py | `-650633.057031` | `-651692.99779861` |
| imaging/rectangular_dspl.py | `1134.94493` | `1170.07439094` |
| imaging/rectangular_mge.py | `-111.368202` | `-82.94939477` |
| multi/delaunay.py | `-6352.67199073` | `-8853.0665931` |
| multi/delaunay_mge.py | `-124.32724392` | `-545.25327979` |
| multi/mge.py | `-2174335.96508048` | `-2173221.43685875` |
| multi/rectangular.py | `-12670.19450898` | `-12928.70087095` |
| multi/rectangular_mge.py | `-6093.81344693` | `-6146.59211318` |

`scripts/CLAUDE.md`: testing-philosophy bullet replaced — hardcoded literals are now documented as intentional regression markers with a regeneration recipe.

Branch name (`feature/jax-relational-baselines`) reflects the original plan (convert to relational); the actual choice during implementation was to keep hardcoded literals and regenerate.

## Test plan
- [x] All 11 regenerated scripts pass locally
- [x] 16 unchanged hardcoded scripts (4 imaging + 9 interferometer + 2 multi + 3 point_source) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)