### PR TITLE
fix: rename stale PYAUTOFIT_TEST_MODE / PYAUTO_WORKSPACE_SMALL_DATASETS env vars to canonical names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ For database scrape test detail see `scripts/database/scrape/CLAUDE.md`.
 
 ## Running Tests
 
-Scripts are run from the repository root **without** `PYAUTOFIT_TEST_MODE=1` — the non-linear searches run for real (using sampler limits like `n_like_max` to keep runtimes short):
+Scripts are run from the repository root **without** `PYAUTO_TEST_MODE=1` — the non-linear searches run for real (using sampler limits like `n_like_max` to keep runtimes short):
 
 ```bash
 python scripts/imaging/model_fit.py

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -9,8 +9,8 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
-  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
   PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
@@ -20,27 +20,31 @@ defaults:
 overrides:
   # JAX likelihood functions test JIT compilation — need JAX enabled and full-size datasets
   - pattern: "jax_likelihood_functions/"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
   # Database scrape scripts need real search output on disk — no test env vars
   - pattern: "database/scrape/"
     unset:
-      - PYAUTOFIT_TEST_MODE
-      - PYAUTO_WORKSPACE_SMALL_DATASETS
+      - PYAUTO_TEST_MODE
+      - PYAUTO_SMALL_DATASETS
       - PYAUTO_DISABLE_JAX
       - PYAUTO_FAST_PLOTS
   # These scripts load pre-committed FITS data at full resolution
   - pattern: "database/scrape/scaling_relation"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "imaging/convolution"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "imaging/model_fit"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "imaging/visualization"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_lp"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_mge"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS]
+    unset: [PYAUTO_SMALL_DATASETS]
+  # Model composition scripts assert prior_count for full-size MGE bases.
+  # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
+  - pattern: "model_composition/"
+    unset: [PYAUTO_SMALL_DATASETS]
   # visualization.py asserts subplot PNG files exist on disk, but
   # PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray so
   # no file is ever written.

--- a/notebooks/CLAUDE.md
+++ b/notebooks/CLAUDE.md
@@ -15,7 +15,7 @@ This workspace is often imported from `/mnt/c/...` and Codex may not be able to 
 
 ## Testing Philosophy
 
-- Scripts run **without** `PYAUTOFIT_TEST_MODE=1` — non-linear searches execute for
+- Scripts run **without** `PYAUTO_TEST_MODE=1` — non-linear searches execute for
   real (using sampler limits like `n_like_max=300` to keep runtime short).
 - No hardcoded expected numerical values in pure-logic or JAX tests.  Assertions
   are relational (e.g. "JAX result matches NumPy result", "deflected grid ≠ input

--- a/notebooks/aggregator/fit_imaging.ipynb
+++ b/notebooks/aggregator/fit_imaging.ipynb
@@ -25,7 +25,7 @@
         "from autolens import fixtures\n",
         "from autofit.non_linear.samples import Sample\n",
         "\n",
-        "os.environ[\"PYAUTOFIT_TEST_MODE\"] = \"1\"\n",
+        "os.environ[\"PYAUTO_TEST_MODE\"] = \"1\"\n",
         "\n",
         "directory = path.dirname(path.realpath(__file__))\n",
         "\n",

--- a/notebooks/aggregator/fit_interferometer.ipynb
+++ b/notebooks/aggregator/fit_interferometer.ipynb
@@ -25,7 +25,7 @@
         "from autolens import fixtures\n",
         "from autofit.non_linear.samples import Sample\n",
         "\n",
-        "os.environ[\"PYAUTOFIT_TEST_MODE\"] = \"1\"\n",
+        "os.environ[\"PYAUTO_TEST_MODE\"] = \"1\"\n",
         "\n",
         "directory = path.dirname(path.realpath(__file__))\n",
         "\n",

--- a/notebooks/aggregator/tracer.ipynb
+++ b/notebooks/aggregator/tracer.ipynb
@@ -25,7 +25,7 @@
         "from autolens import fixtures\n",
         "from autofit.non_linear.samples import Sample\n",
         "\n",
-        "os.environ[\"PYAUTOFIT_TEST_MODE\"] = \"1\"\n",
+        "os.environ[\"PYAUTO_TEST_MODE\"] = \"1\"\n",
         "\n",
         "directory = path.dirname(path.realpath(__file__))\n",
         "\n",

--- a/run_all_scripts.sh
+++ b/run_all_scripts.sh
@@ -14,7 +14,7 @@ find scripts -name "*.py" | sort | while read script; do
     TOTAL=$((TOTAL + 1))
     echo "[$TOTAL] Running: $script"
 
-    output=$(PYAUTOFIT_TEST_MODE=1 python "$script" 2>&1)
+    output=$(PYAUTO_TEST_MODE=1 python "$script" 2>&1)
     exit_code=$?
 
     if [ $exit_code -ne 0 ]; then

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -15,7 +15,7 @@ This workspace is often imported from `/mnt/c/...` and Codex may not be able to 
 
 ## Testing Philosophy
 
-- Scripts run **without** `PYAUTOFIT_TEST_MODE=1` — non-linear searches execute for
+- Scripts run **without** `PYAUTO_TEST_MODE=1` — non-linear searches execute for
   real (using sampler limits like `n_like_max=300` to keep runtime short).
 - `jax_likelihood_functions/` scripts assert their `fitness._vmap` output against a
   hardcoded expected log-likelihood literal (`assert_allclose(np.array(result), <value>, rtol=1e-4)`).

--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -15,7 +15,7 @@ import autolens as al
 from autolens import fixtures
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -15,7 +15,7 @@ import autolens as al
 from autolens import fixtures
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 

--- a/scripts/aggregator/tracer.py
+++ b/scripts/aggregator/tracer.py
@@ -15,7 +15,7 @@ import autolens as al
 from autolens import fixtures
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 


### PR DESCRIPTION
## Summary
The previous `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE` rename pass skipped this repo (active worktree conflict at the time). A general scan also surfaced `PYAUTO_WORKSPACE_SMALL_DATASETS` — set in this build config but never read by any library code (the consumers all check `PYAUTO_SMALL_DATASETS`). Both renames switch silent no-ops to canonical names that actually fire, so smoke tests now correctly skip the sampler and cap datasets to 15×15.

## Scripts Changed
- `scripts/aggregator/tracer.py` — `os.environ["PYAUTOFIT_TEST_MODE"]` → `os.environ["PYAUTO_TEST_MODE"]`
- `scripts/aggregator/fit_imaging.py` — same rename
- `scripts/aggregator/fit_interferometer.py` — same rename
- `notebooks/aggregator/{tracer,fit_imaging,fit_interferometer}.ipynb` — matching cell update
- `config/build/env_vars.yaml` — defaults + override unset lists renamed (test-mode + small-datasets); also adds `model_composition/` to the `unset: [PYAUTO_SMALL_DATASETS]` override list (those scripts assert `prior_count` against full-size MGE bases)
- `run_all_scripts.sh` — inline env var prefix renamed
- `CLAUDE.md`, `scripts/CLAUDE.md`, `notebooks/CLAUDE.md` — doc references updated

Closes #65

## Test Plan
- [ ] Smoke tests pass with new env vars
- [ ] Verify `PYAUTO_TEST_MODE=2` bypass actually fires (sampler skipped)
- [ ] Verify `PYAUTO_SMALL_DATASETS=1` cap actually fires (15×15 grids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)