### PR TITLE
test(jax): add scripts/jax_assertions/ with assertions moved from PyAutoArray

### DIFF
--- a/scripts/jax_assertions/grid_irregular.py
+++ b/scripts/jax_assertions/grid_irregular.py
@@ -1,0 +1,28 @@
+"""
+Jax Assertions: Grid2DIrregular xp Propagation
+==============================================
+
+Verifies that ``Grid2DIrregular.grid_2d_via_deflection_grid_from`` propagates
+the array backend (``np`` or ``jnp``) of the receiver through to the result.
+This matters because downstream code (e.g. ``.square`` calls in mass profile
+deflection arithmetic) needs to keep using the same backend.
+
+The numpy half of this assertion lives in
+``test_autoarray/structures/grids/test_irregular_2d.py::test__grid_2d_via_deflection_grid_from__propagates_xp``;
+this script holds the JAX half so the unit test stays numpy-only.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import autoarray as aa
+
+"""
+__JAX-Backed Receiver -> JAX-Backed Result__
+"""
+grid_jax = aa.Grid2DIrregular(values=jnp.array([[1.0, 1.0], [2.0, 2.0]]), xp=jnp)
+result_jax = grid_jax.grid_2d_via_deflection_grid_from(
+    deflection_grid=jnp.array([[1.0, 0.0], [1.0, 1.0]])
+)
+assert result_jax._xp is jnp
+
+print("grid_irregular: all assertions passed")

--- a/scripts/jax_assertions/knn_interpolator.py
+++ b/scripts/jax_assertions/knn_interpolator.py
@@ -1,0 +1,169 @@
+"""
+Jax Assertions: KNN Interpolator
+================================
+
+Exercises the JAX-based ``KNearestNeighbor`` mesh interpolator path through
+``aa.Inversion``. The interpolator's ``mappings`` cached property calls
+``get_interpolation_weights`` which uses ``jax.vmap`` and ``jax.numpy`` for
+the per-query nearest-neighbor weighting (Wendland C4 kernel).
+
+Asserts the expected ``pix_indexes_for_sub_slim_index`` and
+``pix_weights_for_sub_slim_index`` values for the canonical
+``knn_mapper_9_3x3`` fixture, plus the regularization matrix produced by both
+``aa.reg.AdaptiveBrightness`` (default on the mapper) and
+``aa.reg.AdaptSplit``.
+
+Previously: ``test_autoarray/inversion/inversion/test_factory.py::test__inversion_imaging__via_mapper_knn``.
+"""
+
+import copy
+import numpy as np
+import numpy.testing as npt
+import autoarray as aa
+
+from autoarray import fixtures
+
+"""
+__Setup: KNN Mapper Fixture + Inversion__
+"""
+masked_imaging_7x7_no_blur = fixtures.make_masked_imaging_7x7_no_blur()
+knn_mapper_9_3x3 = fixtures.make_knn_mapper_9_3x3()
+regularization_adaptive_brightness_split = (
+    fixtures.make_regularization_adaptive_brightness_split()
+)
+
+inversion = aa.Inversion(
+    dataset=masked_imaging_7x7_no_blur,
+    linear_obj_list=[knn_mapper_9_3x3],
+)
+
+"""
+__pix_indexes_for_sub_slim_index (rows 0-2)__
+
+Triggers the JAX nearest-neighbor weight computation.
+"""
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_indexes_for_sub_slim_index[0, :],
+    [1, 0, 4, 6, 2, 5, 3, 7, 8],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_indexes_for_sub_slim_index[1, :],
+    [1, 0, 2, 4, 6, 3, 5, 7, 8],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_indexes_for_sub_slim_index[2, :],
+    [1, 0, 4, 6, 2, 5, 3, 7, 8],
+    rtol=1.0e-4,
+)
+
+"""
+__pix_weights_for_sub_slim_index (rows 0-2)__
+
+Wendland C4 weights from the JAX vmap'd interpolator.
+"""
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_weights_for_sub_slim_index[0, :],
+    [
+        0.24139248,
+        0.20182463,
+        0.13465525,
+        0.12882639,
+        0.12169429,
+        0.08682546,
+        0.07062276,
+        0.00982079,
+        0.00433794,
+    ],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_weights_for_sub_slim_index[1, :],
+    [
+        0.23255487,
+        0.22727716,
+        0.14466056,
+        0.11643257,
+        0.09868897,
+        0.08878719,
+        0.07744259,
+        0.01010399,
+        0.0040521,
+    ],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    knn_mapper_9_3x3.pix_weights_for_sub_slim_index[2, :],
+    [
+        0.2334672,
+        0.1785593,
+        0.153417,
+        0.15099354,
+        0.11075057,
+        0.09986048,
+        0.06060822,
+        0.00869774,
+        0.00364596,
+    ],
+    rtol=1.0e-4,
+)
+
+"""
+__Inversion Regularization (AdaptiveBrightness, default)__
+"""
+assert isinstance(inversion, aa.InversionImagingMapping)
+
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 0],
+    [4.00000001, -1.0, -1.0],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 1],
+    [-1.0, 3.00000001, 0.0],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 2],
+    [-1.0, 0.0, 4.00000001],
+    rtol=1.0e-4,
+)
+
+npt.assert_allclose(
+    inversion.log_det_curvature_reg_matrix_term, 10.417803331712355, rtol=1.0e-4
+)
+npt.assert_allclose(
+    inversion.mapped_reconstructed_operated_data, np.ones(9), rtol=1.0e-4
+)
+
+"""
+__Inversion Regularization (AdaptSplit)__
+
+Swap the regularization to ``AdaptSplit`` and re-run the inversion.
+"""
+mapper = copy.copy(knn_mapper_9_3x3)
+mapper.regularization = regularization_adaptive_brightness_split
+
+inversion = aa.Inversion(
+    dataset=masked_imaging_7x7_no_blur,
+    linear_obj_list=[mapper],
+)
+
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 0],
+    [22.47519068, -16.373819, 8.39424766],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 1],
+    [-16.373819, 112.1402519, -13.56808248],
+    rtol=1.0e-4,
+)
+npt.assert_allclose(
+    inversion.regularization_matrix[0:3, 2],
+    [8.39424766, -13.56808248, 26.10743213],
+    rtol=1.0e-4,
+)
+
+print("knn_interpolator: all assertions passed")

--- a/scripts/jax_assertions/nnls.py
+++ b/scripts/jax_assertions/nnls.py
@@ -1,0 +1,91 @@
+"""
+Jax Assertions: NNLS (Positive-Only Solver)
+===========================================
+
+Verifies the Jacobi-preconditioned ``jaxnnls`` path through
+``aa.util.inversion.reconstruction_positive_only_from`` with ``xp=jnp``:
+
+1. **Ill-conditioned curvature matrix** — Without preconditioning the raw
+   ``jaxnnls`` backward pass returns NaN gradients. The Jacobi
+   preconditioning re-parameterises the NNLS problem so the solve converges
+   and ``jax.value_and_grad`` produces finite gradients.
+
+2. **Well-conditioned curvature matrix** — Jacobi preconditioning is a
+   change of coordinates, so the forward primal solution must match the raw
+   ``jaxnnls.solve_nnls_primal`` result to within solver tolerance.
+
+Previously: two ``test__reconstruction_positive_only_from__jax_*`` tests in
+``test_autoarray/inversion/inversion/test_inversion_util.py``.
+"""
+
+import jax
+import jax.numpy as jnp
+import jaxnnls
+import numpy as np
+import autoarray as aa
+
+"""
+__Ill-conditioned: Finite Gradients via Jacobi Preconditioning__
+
+Build a small symmetric positive-definite Q with cond(Q) ~ 1e7. Without
+preconditioning this is enough to break the raw ``jaxnnls`` backward pass.
+"""
+rng = np.random.default_rng(0)
+n = 10
+U, _ = np.linalg.qr(rng.standard_normal((n, n)))
+eigs = np.logspace(-4, 3, n)
+Q_np = (U * eigs) @ U.T
+Q_np = 0.5 * (Q_np + Q_np.T)
+q_np = rng.standard_normal(n)
+
+Q = jnp.array(Q_np)
+q = jnp.array(q_np)
+
+
+def loss(q_in):
+    x = aa.util.inversion.reconstruction_positive_only_from(
+        data_vector=q_in,
+        curvature_reg_matrix=Q,
+        xp=jnp,
+    )
+    return jnp.sum(x)
+
+
+value, grad = jax.value_and_grad(loss)(q)
+
+assert np.isfinite(float(value))
+grad_np = np.array(grad)
+assert np.all(np.isfinite(grad_np)), (
+    f"gradient has {np.sum(~np.isfinite(grad_np))} non-finite entries"
+)
+
+"""
+__Well-conditioned: Preconditioned Solve Matches Raw jaxnnls__
+
+For a moderately-conditioned problem where the raw solver also converges,
+the preconditioned solution must match ``jaxnnls.solve_nnls_primal`` to
+solver tolerance.
+"""
+rng = np.random.default_rng(1)
+n = 8
+U, _ = np.linalg.qr(rng.standard_normal((n, n)))
+eigs = np.linspace(0.5, 5.0, n)  # well-conditioned
+Q_np = (U * eigs) @ U.T
+Q_np = 0.5 * (Q_np + Q_np.T)
+q_np = rng.standard_normal(n)
+
+Q = jnp.array(Q_np)
+q = jnp.array(q_np)
+
+x_raw = np.array(jaxnnls.solve_nnls_primal(Q, q))
+x_pc = np.array(
+    aa.util.inversion.reconstruction_positive_only_from(
+        data_vector=q,
+        curvature_reg_matrix=Q,
+        xp=jnp,
+    )
+)
+
+np.testing.assert_allclose(x_pc, x_raw, rtol=1e-6, atol=1e-8)
+
+print("nnls: all assertions passed")

--- a/scripts/jax_assertions/pytree.py
+++ b/scripts/jax_assertions/pytree.py
@@ -1,0 +1,78 @@
+"""
+Jax Assertions: AbstractNDArray Pytree Registration
+===================================================
+
+Tests gated JAX pytree registration of ``AbstractNDArray`` subclasses,
+following the three-step pattern from ``hessian_jax.py``:
+
+1. NumPy path — confirm autoarray type with ``np.ndarray`` backing, no
+   pytree registration.
+2. JAX path outside JIT — same autoarray type with ``jax.Array`` backing;
+   pytree registered.
+3. JAX path through ``jax.jit`` — round-trip the instance and assert the
+   output carries a ``jax.Array`` leaf.
+
+Previously: ``test_autoarray/test_jax_pytree.py``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+
+from autoarray.abstract_ndarray import AbstractNDArray, _pytree_registered_classes
+
+
+class _LeafArray(AbstractNDArray):
+    """Minimal concrete ``AbstractNDArray`` with no nested autoarray children.
+
+    Isolates the pytree-registration machinery from the larger autoarray
+    hierarchy: a real ``Array2D`` also carries a ``Mask2D`` and other nested
+    ``AbstractNDArray`` children whose own registration is covered by
+    follow-up steps in the ``fit-imaging-pytree`` task.
+    """
+
+    @property
+    def native(self):
+        return self
+
+
+"""
+__NumPy Path: No Pytree Registration__
+"""
+_pytree_registered_classes.discard(_LeafArray)
+
+arr = _LeafArray(np.array([1.0, 2.0, 3.0]))
+
+assert isinstance(arr._array, np.ndarray)
+assert _LeafArray not in _pytree_registered_classes
+
+"""
+__JAX Path Outside JIT: Pytree Registered Once__
+
+Constructing on the JAX path registers the class. A second construction is
+a no-op; the class stays registered.
+"""
+_pytree_registered_classes.discard(_LeafArray)
+
+arr_jax = _LeafArray(jnp.array([1.0, 2.0, 3.0]), xp=jnp)
+
+assert isinstance(arr_jax._array, jnp.ndarray)
+assert _LeafArray in _pytree_registered_classes
+
+_LeafArray(jnp.array([4.0, 5.0]), xp=jnp)
+assert _LeafArray in _pytree_registered_classes
+
+"""
+__JAX Path Through jax.jit: Round-trip Returns Wrapper with jax.Array Leaf__
+"""
+arr_jax = _LeafArray(jnp.array([1.0, 2.0, 3.0]), xp=jnp)
+assert _LeafArray in _pytree_registered_classes
+
+result = jax.jit(lambda a: a)(arr_jax)
+
+assert isinstance(result, _LeafArray)
+assert isinstance(result._array, jnp.ndarray)
+npt.assert_allclose(np.asarray(result._array), np.asarray(arr_jax._array))
+
+print("pytree: all assertions passed")

--- a/scripts/jax_assertions/sparse_operators.py
+++ b/scripts/jax_assertions/sparse_operators.py
@@ -1,0 +1,264 @@
+"""
+Jax Assertions: Sparse Operators
+================================
+
+Cross-implementation parity checks for the JAX-accelerated sparse-operator
+fast paths in ``autoarray.inversion``:
+
+- ``data_vector_via_psf_weighted_data_from`` (uses ``jax.ops.segment_sum``) is
+  compared against the dense ``data_vector_via_blurred_mapping_matrix_from``
+  reference.
+- ``ImagingSparseOperator.from_noise_map_and_psf`` (FFT-based curvature
+  diagonal in JAX) is compared against the dense
+  ``curvature_matrix_via_mapping_matrix_from`` reference.
+- ``InterferometerSparseOperator.from_nufft_precision_operator`` (FFT-based
+  curvature in JAX) is compared against
+  ``curvature_matrix_diag_via_psf_weighted_noise_from``.
+
+These previously lived as pytest tests in ``test_autoarray/`` but pulled the
+``jax`` import into the library unit-test run. They are now executable
+scripts so unit tests stay numpy-only.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import autoarray as aa
+
+"""
+__Data Vector via PSF-Weighted Data (segment_sum) vs Blurred Mapping Matrix__
+
+For two sub-grid sizes, build a mapper, compute the data vector two ways
+(dense blurred mapping matrix, and sparse-triplet path through
+``data_vector_via_psf_weighted_data_from`` which uses
+``jax.ops.segment_sum``), and assert agreement to 1e-4.
+"""
+mask = aa.Mask2D.circular(shape_native=(51, 51), pixel_scales=0.1, radius=2.0)
+
+image = np.random.uniform(size=mask.shape_native)
+image = aa.Array2D(values=image, mask=mask)
+
+noise_map = np.random.uniform(size=mask.shape_native)
+noise_map = aa.Array2D(values=noise_map, mask=mask)
+
+convolver = aa.Convolver.from_gaussian(
+    shape_native=(7, 7), pixel_scales=mask.pixel_scales, sigma=1.0, normalize=True
+)
+
+psf = convolver
+
+mesh = aa.mesh.RectangularUniform(shape=(20, 20))
+
+for sub_size in range(1, 3):
+
+    grid = aa.Grid2D.from_mask(mask=mask, over_sample_size=sub_size)
+
+    interpolator = mesh.interpolator_from(
+        source_plane_data_grid=grid, source_plane_mesh_grid=None
+    )
+
+    mapper = aa.Mapper(interpolator=interpolator)
+
+    mapping_matrix = mapper.mapping_matrix
+
+    blurred_mapping_matrix = psf.convolved_mapping_matrix_from(
+        mapping_matrix=mapping_matrix, mask=mask
+    )
+
+    data_vector = (
+        aa.util.inversion_imaging.data_vector_via_blurred_mapping_matrix_from(
+            blurred_mapping_matrix=blurred_mapping_matrix,
+            image=image,
+            noise_map=noise_map,
+        )
+    )
+
+    rows, cols, vals = aa.util.mapper.sparse_triplets_from(
+        pix_indexes_for_sub=mapper.pix_indexes_for_sub_slim_index,
+        pix_weights_for_sub=mapper.pix_weights_for_sub_slim_index,
+        slim_index_for_sub=mapper.slim_index_for_sub_slim_index,
+        fft_index_for_masked_pixel=mask.fft_index_for_masked_pixel,
+        sub_fraction_slim=mapper.over_sampler.sub_fraction.array,
+    )
+
+    weight_map = image.array / (noise_map.array**2)
+    weight_map = aa.Array2D(values=weight_map, mask=noise_map.mask)
+
+    psf_weighted_data = aa.util.inversion_imaging.psf_weighted_data_from(
+        weight_map_native=weight_map.native.array,
+        kernel_native=convolver.kernel.native.array,
+        native_index_for_slim_index=mask.derive_indexes.native_for_slim.astype(
+            "int"
+        ),
+    )
+
+    data_vector_via_psf_weighted_noise = (
+        aa.util.inversion_imaging.data_vector_via_psf_weighted_data_from(
+            psf_weighted_data=psf_weighted_data,
+            rows=rows,
+            cols=cols,
+            vals=vals,
+            S=mesh.pixels,
+        )
+    )
+
+    npt.assert_allclose(
+        np.asarray(data_vector_via_psf_weighted_noise),
+        np.asarray(data_vector),
+        rtol=1.0e-4,
+    )
+
+"""
+__ImagingSparseOperator vs Curvature Matrix via Mapping Matrix__
+
+Build an ``ImagingSparseOperator`` (FFT/JAX-based curvature) and compare its
+diagonal curvature against the dense
+``curvature_matrix_via_mapping_matrix_from`` reference for an
+adaptive-density rectangular mesh, to abs tol 1e-4.
+"""
+mask = aa.Mask2D.circular(shape_native=(21, 21), pixel_scales=0.1, radius=0.8)
+
+noise_map = np.random.uniform(size=mask.shape_native)
+noise_map = aa.Array2D(values=noise_map, mask=mask)
+
+kernel = aa.Convolver.from_gaussian(
+    shape_native=(5, 5), pixel_scales=mask.pixel_scales, sigma=1.0, normalize=True
+)
+
+psf = kernel
+
+sparse_operator = aa.ImagingSparseOperator.from_noise_map_and_psf(
+    data=noise_map,
+    noise_map=noise_map,
+    psf=psf.kernel.native,
+)
+
+mesh = aa.mesh.RectangularAdaptDensity(shape=(8, 8))
+
+interpolator = mesh.interpolator_from(
+    source_plane_data_grid=mask.derive_grid.unmasked,
+    source_plane_mesh_grid=None,
+)
+
+mapper = aa.Mapper(interpolator=interpolator)
+
+mapping_matrix = mapper.mapping_matrix
+
+rows, cols, vals = aa.util.mapper.sparse_triplets_from(
+    pix_indexes_for_sub=mapper.pix_indexes_for_sub_slim_index,
+    pix_weights_for_sub=mapper.pix_weights_for_sub_slim_index,
+    slim_index_for_sub=mapper.slim_index_for_sub_slim_index,
+    fft_index_for_masked_pixel=mask.fft_index_for_masked_pixel,
+    sub_fraction_slim=mapper.over_sampler.sub_fraction.array,
+    return_rows_slim=False,
+)
+
+curvature_matrix_via_sparse_operator = sparse_operator.curvature_matrix_diag_from(
+    rows,
+    cols,
+    vals,
+    S=mesh.shape[0] * mesh.shape[1],
+)
+
+curvature_matrix_via_sparse_operator = (
+    aa.util.inversion_imaging.curvature_matrix_mirrored_from(
+        curvature_matrix=curvature_matrix_via_sparse_operator,
+    )
+)
+
+blurred_mapping_matrix = psf.convolved_mapping_matrix_from(
+    mapping_matrix=mapping_matrix, mask=mask
+)
+
+curvature_matrix = aa.util.inversion.curvature_matrix_via_mapping_matrix_from(
+    mapping_matrix=blurred_mapping_matrix,
+    noise_map=noise_map,
+)
+
+npt.assert_allclose(
+    np.asarray(curvature_matrix_via_sparse_operator),
+    np.asarray(curvature_matrix),
+    atol=1.0e-4,
+)
+
+"""
+__InterferometerSparseOperator vs PSF-Weighted Noise Curvature__
+
+Build an ``InterferometerSparseOperator`` from the NUFFT precision operator
+and compare its sparse-operator curvature matrix against the
+``curvature_matrix_diag_via_psf_weighted_noise_from`` reference, to rel
+tolerance 1e-4.
+"""
+noise_map = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+uv_wavelengths = np.array(
+    [[0.0001, 2.0, 3000.0, 50000.0, 200000.0], [3000.0, 2.0, 0.0001, 10.0, 5000.0]]
+)
+
+grid = aa.Grid2D.uniform(shape_native=(3, 3), pixel_scales=0.0005)
+
+mapping_matrix = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0],
+    ]
+)
+
+nufft_precision_operator = (
+    aa.util.inversion_interferometer.nufft_precision_operator_from(
+        noise_map_real=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        shape_masked_pixels_2d=(3, 3),
+        grid_radians_2d=np.array(grid.native),
+    )
+)
+
+native_index_for_slim_index = np.array(
+    [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]]
+)
+
+psf_weighted_noise = (
+    aa.util.inversion_interferometer.nufft_weighted_noise_via_sparse_operator_from(
+        translation_invariant_kernel=nufft_precision_operator,
+        native_index_for_slim_index=native_index_for_slim_index,
+    )
+)
+
+curvature_matrix_via_nufft_weighted_noise = (
+    aa.util.inversion.curvature_matrix_diag_via_psf_weighted_noise_from(
+        psf_weighted_noise=psf_weighted_noise, mapping_matrix=mapping_matrix
+    )
+)
+
+pix_indexes_for_sub_slim_index = np.array(
+    [[0], [2], [1], [1], [2], [2], [0], [2], [0]]
+)
+
+pix_weights_for_sub_slim_index = np.ones(shape=(9, 1))
+
+sparse_operator = aa.InterferometerSparseOperator.from_nufft_precision_operator(
+    nufft_precision_operator=nufft_precision_operator,
+    dirty_image=None,
+)
+
+curvature_matrix_via_preload = (
+    sparse_operator.curvature_matrix_via_sparse_operator_from(
+        pix_indexes_for_sub_slim_index=pix_indexes_for_sub_slim_index,
+        pix_weights_for_sub_slim_index=pix_weights_for_sub_slim_index,
+        fft_index_for_masked_pixel=grid.mask.fft_index_for_masked_pixel,
+        pix_pixels=3,
+    )
+)
+
+npt.assert_allclose(
+    np.asarray(curvature_matrix_via_nufft_weighted_noise),
+    np.asarray(curvature_matrix_via_preload),
+    rtol=1.0e-4,
+)
+
+print("sparse_operators: all assertions passed")


### PR DESCRIPTION
## Summary

Five new scripts in `scripts/jax_assertions/` holding cross-xp parity and jax-only behavior assertions that previously lived as pytest tests in `PyAutoArray/test_autoarray/` but pulled jax imports into the library unit test run.

| Script | What it asserts |
|---|---|
| `sparse_operators.py` | `data_vector_via_psf_weighted_data_from` (segment_sum) ≈ blurred mapping matrix; `ImagingSparseOperator.from_noise_map_and_psf` ≈ dense curvature; `InterferometerSparseOperator.from_nufft_precision_operator` ≈ psf-weighted-noise curvature |
| `knn_interpolator.py` | KNN mapper `pix_indexes_for_sub_slim_index` / `pix_weights_for_sub_slim_index` and resulting inversion regularization (default + AdaptSplit) |
| `nnls.py` | Jacobi-preconditioned `reconstruction_positive_only_from` produces finite gradients on ill-conditioned Q; matches raw `jaxnnls.solve_nnls_primal` on well-conditioned Q |
| `pytree.py` | `AbstractNDArray` pytree registration: numpy path doesn't register, jax path registers once, jax.jit round-trips through `_LeafArray` |
| `grid_irregular.py` | `Grid2DIrregular.grid_2d_via_deflection_grid_from` propagates `xp=jnp` through to result |

## Why

See the companion PR on PyAutoArray: [PyAutoArray#feature/jax-assertions-move](https://github.com/PyAutoLabs/PyAutoArray/pulls?q=is%3Apr+head%3Afeature%2Fjax-assertions-move).

In short: keep `test_autoarray/` numpy-only so the no-jax CI matrix stays green and local dev runs don't pay the jax import tax.

## Style

Each script follows the established workspace_test convention:
- Module docstring + `__Section__` headers
- `npt.assert_allclose` instead of `pytest.approx`
- Inline construction (no pytest fixtures or `parameterize`)
- Final `print("<name>: all assertions passed")` so `run_all_scripts.sh` produces visible success markers

## Test plan

- [x] Each script exits 0 individually under `python scripts/jax_assertions/<name>.py` (locally verified)
- [ ] `run_all_scripts.sh` passes after merge