### PR TITLE
fix: align point-source test simulators with realistic noise scales

### DIFF
--- a/scripts/jax_likelihood_functions/point_source/simulator.py
+++ b/scripts/jax_likelihood_functions/point_source/simulator.py
@@ -49,10 +49,11 @@ positions = solver.solve(
     tracer=tracer, source_plane_coordinate=source_galaxy.point_0.centre
 )
 
+# Position noise = 5 mas (HST PSF-centroiding precision), not the imaging pixel scale.
 dataset = al.PointDataset(
     name="point_0",
     positions=positions,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=0.005,
 )
 
 al.output_to_json(

--- a/scripts/point_source/simulators/point_source.py
+++ b/scripts/point_source/simulators/point_source.py
@@ -126,16 +126,18 @@ aplt.plot_array(
 
 """
 Create a point-source dictionary data object and output this to a `.json` file, which is the format used to load and
-analyse the dataset.
+analyse the dataset. Position noise = 5 mas (HST PSF-centroiding precision); flux noise = 5% relative (microlensing-
+dominated regime). See `autolens_workspace/scripts/point_source/simulator.py` for rationale.
 """
+position_noise = 0.005
+flux_rel_noise = 0.05
+
 dataset = al.PointDataset(
     name="point_0",
     positions=positions,
-    positions_noise_map=grid.pixel_scale,
+    positions_noise_map=position_noise,
     fluxes=fluxes,
-    fluxes_noise_map=al.ArrayIrregular(
-        values=[np.sqrt(flux) for _ in range(len(fluxes))]
-    ),
+    fluxes_noise_map=al.ArrayIrregular(values=flux_rel_noise * np.asarray(fluxes)),
 )
 
 al.output_to_json(


### PR DESCRIPTION
## Summary

Align the point-source test simulators with the realistic noise scales applied in
[autolens_workspace#125](https://github.com/PyAutoLabs/autolens_workspace/issues/125):
position noise = 5 mas (HST PSF-centroiding precision, not the imaging pixel
scale), flux noise = 5% relative.

## Scripts Changed

- `scripts/point_source/simulators/point_source.py` — position noise and flux noise
- `scripts/jax_likelihood_functions/point_source/simulator.py` — position noise

## Test Plan

- [ ] Smoke tests pass for autolens_workspace_test

🤖 Generated with [Claude Code](https://claude.com/claude-code)