### PR TITLE
chore: park three modeling_visualization_jit autolens tests as SLOW

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -23,6 +23,9 @@
 - database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_pix # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - imaging/visualization # NEEDS_FIX 2026-04-10 - AssertionError: dataset.png missing after visualization refactor
+- imaging/modeling_visualization_jit # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap (autogalaxy variant ~90s); unblocked by PR #70 from prior `expected jax.Array, got numpy.float64` AssertionError, now hits perf wall
+- imaging/modeling_visualization_jit_delaunay # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap; same root cause as modeling_visualization_jit
+- imaging/modeling_visualization_jit_rectangular # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 301s cap; same root cause as modeling_visualization_jit
 - jax_likelihood_functions/imaging/delaunay_mge # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile


### PR DESCRIPTION
## Summary
Three imaging integration tests in `autolens_workspace_test` now time out at the 300s per-script cap during release-prep mega-runs:

| Script | Result |
|---|---|
| `imaging/modeling_visualization_jit` | TIMEOUT 300s |
| `imaging/modeling_visualization_jit_delaunay` | TIMEOUT 300s |
| `imaging/modeling_visualization_jit_rectangular` | TIMEOUT 301s |

This is **not a regression**. PR #70 (`fix(env): unblock modeling_visualization_jit tests in CI defaults`) cleared the prior `AssertionError: expected jax.Array, got numpy.float64` that masked this perf issue. Now the assertion no longer fires, the autogalaxy sibling passes in ~88.6s, and the three autolens variants run far enough to hit the 300s cap — JIT compile + full visualization on autolens is ~3.5× slower than the autogalaxy equivalent.

This was Cluster D of the recent release-prep triage. Parking via the standard \`# SLOW <YYYY-MM-DD>\` convention so mega-runs surface them with the existing loud-warning banner. A follow-up perf issue will track the autolens-vs-autogalaxy disparity (the actual root-cause investigation, option (c)).

## Files Changed
- \`config/build/no_run.yaml\` — three new SLOW entries inserted in the imaging block, mirroring the format of the existing \`database/scrape/*\` SLOW entries (lines 21–24).

## Test Plan
- [x] Visual diff inspection — three lines added, format matches existing SLOW entries.
- [ ] Confirmed by next mega-run: the three scripts no longer appear in the timeout list and instead surface in the SLOW-warning banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)