### PR TITLE
fix: rebaseline JAX point-source likelihood literals after noise-scale change

### DIFF
--- a/dataset/point_source/simple/point_dataset_positions_only.json
+++ b/dataset/point_source/simple/point_dataset_positions_only.json
@@ -3,6 +3,22 @@
     "class_path": "autolens.point.dataset.PointDataset",
     "arguments": {
         "name": "point_0",
+        "fluxes_noise_map": null,
+        "positions_noise_map": {
+            "type": "instance",
+            "class_path": "autoarray.structures.arrays.irregular.ArrayIrregular",
+            "arguments": {
+                "values": {
+                    "type": "ndarray",
+                    "array": [
+                        0.005,
+                        0.005
+                    ],
+                    "dtype": "float64"
+                }
+            }
+        },
+        "time_delays": null,
         "positions": {
             "type": "instance",
             "class_path": "autoarray.structures.grids.irregular_2d.Grid2DIrregular",
@@ -23,23 +39,8 @@
                 }
             }
         },
-        "time_delays_noise_map": null,
         "fluxes": null,
-        "positions_noise_map": {
-            "type": "instance",
-            "class_path": "autoarray.structures.arrays.irregular.ArrayIrregular",
-            "arguments": {
-                "values": {
-                    "type": "ndarray",
-                    "array": [
-                        0.2,
-                        0.2
-                    ],
-                    "dtype": "float64"
-                }
-            }
-        },
-        "time_delays": null,
-        "fluxes_noise_map": null
+        "redshift": null,
+        "time_delays_noise_map": null
     }
 }

--- a/dataset/point_source/simple/tracer.json
+++ b/dataset/point_source/simple/tracer.json
@@ -2,11 +2,6 @@
     "type": "instance",
     "class_path": "autolens.lens.tracer.Tracer",
     "arguments": {
-        "cosmology": {
-            "type": "instance",
-            "class_path": "autogalaxy.cosmology.model.Planck15",
-            "arguments": {}
-        },
         "galaxies": {
             "type": "list",
             "values": [
@@ -48,6 +43,11 @@
                     }
                 }
             ]
+        },
+        "cosmology": {
+            "type": "instance",
+            "class_path": "autogalaxy.cosmology.model.Planck15",
+            "arguments": {}
         }
     }
 }

--- a/scripts/jax_likelihood_functions/point_source/image_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/image_plane.py
@@ -132,7 +132,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    1.313508,
+    -83.38049778,
     rtol=1e-4,
     err_msg="point_source/image_plane: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -233,7 +233,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    1.313508,
+    -83.38049778,
     rtol=1e-4,
     err_msg="point: JAX vmap likelihood mismatch",
 )

--- a/scripts/jax_likelihood_functions/point_source/source_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/source_plane.py
@@ -143,7 +143,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 # Regression constant filled in on first run against the workspace_test
 # seeded PointDataset (``scripts/jax_likelihood_functions/point_source/simulator.py``).
-EXPECTED_VMAP_LOG_LIKELIHOOD_SOURCE_PLANE = -199.1555813
+EXPECTED_VMAP_LOG_LIKELIHOOD_SOURCE_PLANE = -331481.25978149
 
 np.testing.assert_allclose(
     np.array(result),
@@ -180,7 +180,7 @@ fit_np = analysis_np.fit_from(instance=instance)
 log_likelihood_np = float(fit_np.log_likelihood)
 print("NumPy fit.log_likelihood:", log_likelihood_np)
 
-EXPECTED_EAGER_LOG_LIKELIHOOD_SOURCE_PLANE = -199.1555813
+EXPECTED_EAGER_LOG_LIKELIHOOD_SOURCE_PLANE = -331481.26508536364
 
 np.testing.assert_allclose(
     log_likelihood_np,


### PR DESCRIPTION
## Summary
Rebaseline three JAX point-source likelihood literals after the realistic noise change in 931a381 (`positions_noise_map` 0.2" → 0.005"). The committed seed dataset was last regenerated under the old noise scale, so any fresh simulator run was producing likelihoods that did not match the hardcoded constants. This commit regenerates the seed dataset and updates the literals so both canonical-checkout runs and clean re-simulations pass.

## Scripts Changed
- `scripts/jax_likelihood_functions/point_source/image_plane.py` — rebaseline `expected_likelihood` from `1.313508` to `-83.38049778`
- `scripts/jax_likelihood_functions/point_source/point.py` — rebaseline `expected_likelihood` from `1.313508` to `-83.38049778` (identical to `image_plane.py`; both scripts load the same dataset and evaluate at the same prior medians)
- `scripts/jax_likelihood_functions/point_source/source_plane.py` — rebaseline `EXPECTED_VMAP_LOG_LIKELIHOOD_SOURCE_PLANE` to `-331481.25978149` and `EXPECTED_EAGER_LOG_LIKELIHOOD_SOURCE_PLANE` to `-331481.26508536364`. The 1664x magnitude jump matches chi-squared rescaling under a 40x position-noise reduction (1/sigma² scaling).

Also regenerates `dataset/point_source/simple/{point_dataset_positions_only,tracer}.json` so the on-disk seed dataset, the simulator code, and the literals are consistent. Without the regeneration, anyone who deletes the local dataset (forcing `should_simulate` to fire) would hit the same failure on next run.

## Test Plan
- [ ] Smoke tests pass for `autolens_workspace_test`
- [ ] All three scripts exit 0 (verified locally; logs at `/tmp/cluster_c_*_final.log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)