### PR TITLE
fix: unset PYAUTO_SMALL_DATASETS for multi/visualization_imaging

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -56,3 +56,12 @@ overrides:
   # and savefig active (Part 2 asserts fit.png lands on disk).
   - pattern: "imaging/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
+  # multi/visualization_imaging loads the 150x150 lens_sersic dataset from
+  # disk via Imaging.from_fits (which does not honour SMALL_DATASETS) and
+  # builds its mask via al.Mask2D.circular (which DOES cap to 15x15 under
+  # PYAUTO_SMALL_DATASETS=1, even when shape_native is explicit). The
+  # mismatch raises a (150,150) vs (15,15) broadcast error on apply_mask.
+  # The script does not run a non-linear search, so it is only useful at
+  # full resolution; just unset the cap.
+  - pattern: "multi/visualization_imaging"
+    unset: [PYAUTO_SMALL_DATASETS]


### PR DESCRIPTION
## Summary
The triage runner (driven by `autolens_workspace_test/config/build/env_vars.yaml`'s `defaults:` block, which sets `PYAUTO_SMALL_DATASETS: "1"`) reproducibly fails `scripts/multi/visualization_imaging.py` with `ValueError: operands could not be broadcast together with shapes (150,150) (15,15)` at `dataset.apply_mask(mask=mask)`. The script already derives mask shape from `dataset.shape_native`, but `al.Mask2D.circular` silently caps to 15×15 under the env var while `Imaging.from_fits` does not, leaving the mask and dataset shape-mismatched. Unset the cap for this script via the existing override mechanism.

## Scripts Changed
- `config/build/env_vars.yaml` — added `multi/visualization_imaging` to the override list (unsetting `PYAUTO_SMALL_DATASETS`). Same shape as the existing `imaging/visualization`, `imaging/model_fit`, etc. overrides; comment block explains the asymmetry between `Mask2D.circular`'s SMALL_DATASETS handling and `Imaging.from_fits`'s lack thereof.

## Test Plan
- [x] `env_config.build_env_for_script` resolves `multi/visualization_imaging.py` → `PYAUTO_SMALL_DATASETS` unset.
- [x] Sibling `multi/visualization_interferometer.py` and other `multi/` scripts still see `PYAUTO_SMALL_DATASETS=1` (no bleed).
- [x] Script runs to exit 0 under simulated triage env (`PYAUTO_TEST_MODE=2 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1` with `PYAUTO_SMALL_DATASETS` unset).
- [x] `multi/visualization_imaging.py` is not in `smoke_tests.txt` (not added).

## Follow-up
`Mask2D.circular`'s `PYAUTO_SMALL_DATASETS=1` cap silently overrides an explicit `shape_native` argument — a real library wart in `PyAutoArray/autoarray/mask/mask_2d.py:363-366`. A future PR could either only apply the cap when `shape_native` is at its default, or make `Imaging.from_fits` also honour the env var so the dataset and mask stay consistent. Worth filing as its own `PyAutoArray` issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)