### PR TITLE
ci: install [optional] on 3.13, pin jax<0.7 for tfp compat

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -68,13 +68,9 @@ jobs:
       run: |
         pip install --upgrade pip setuptools wheel
         pip install pyyaml
-        if [ "${{ matrix.python-version }}" = "3.12" ]; then
-          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
-          pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
-        else
-          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
-          pip install numba
-        fi
+        pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy ./PyAutoLens
+        pip install "jax<0.7" "jaxlib<0.7"
+        pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         pip install tensorflow-probability==0.25.0
     - name: Prepare cache dirs
       run: |


### PR DESCRIPTION
## Summary
- 3.13 path no longer skips `[optional]` extras — JAX 0.6.x has cp313 wheels.
- Pin `jax<0.7 jaxlib<0.7` so the resolver stays on a tfp-0.25.0-compatible JAX.
- Should fix all 7 `ModuleNotFoundError: No module named 'jax'` failures on 3.13.

## Test plan
- [ ] CI smoke on this PR (3.12 and 3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)