### PR TITLE
docs: render __Contents__ blocks as Markdown lists

### DIFF
--- a/scripts/model_composition/multi_galaxy_mge.py
+++ b/scripts/model_composition/multi_galaxy_mge.py
@@ -20,13 +20,13 @@ compatibility.
 
 __Contents__
 
-**Lens Galaxy Composition:** MGE bulge with gaussian_per_basis=2 + Isothermal + ExternalShear.
-**Source Galaxy Composition:** MGE bulge with gaussian_per_basis=1.
-**Full Model:** af.Collection wrapping lens + source galaxies.
-**MGE Prior Identity:** Within-basis sharing and cross-basis independence of priors.
-**Identifier Stability:** Hardcoded regression anchor for the full model.
-**Serialization Round-Trip:** dict/from_dict preserves prior count and path structure.
-**Model Info:** Human-readable info string contains expected component names.
+- **Lens Galaxy Composition:** MGE bulge with gaussian_per_basis=2 + Isothermal + ExternalShear.
+- **Source Galaxy Composition:** MGE bulge with gaussian_per_basis=1.
+- **Full Model:** af.Collection wrapping lens + source galaxies.
+- **MGE Prior Identity:** Within-basis sharing and cross-basis independence of priors.
+- **Identifier Stability:** Hardcoded regression anchor for the full model.
+- **Serialization Round-Trip:** dict/from_dict preserves prior count and path structure.
+- **Model Info:** Human-readable info string contains expected component names.
 """
 
 import autofit as af


### PR DESCRIPTION
## Summary

Convert the `__Contents__` block in `scripts/model_composition/multi_galaxy_mge.py` from plain `**Section:**` lines into Markdown list bullets (`- **Section:**`).

Without bullet markers, GitHub and JupyterLab collapse the contents block into one continuous paragraph in the generated notebook's first markdown cell. The fix is purely Markdown.

## Scripts Changed

1 script — `scripts/model_composition/multi_galaxy_mge.py`. (This is the only script in this repo with a `__Contents__` block.)

## Test Plan
- [ ] Smoke tests pass

Refs PyAutoLabs/autolens_workspace#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)