### PR TITLE
fix: register_model in visualization_jax.py to actually exercise JIT path

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -35,8 +35,14 @@ overrides:
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "imaging/model_fit"
     unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "imaging/visualization"
+  - pattern: "imaging/visualization.py"
     unset: [PYAUTO_SMALL_DATASETS]
+  # visualization_jax exercises the jit-cached fit_for_visualization path
+  # (registered model + autoarray pytrees). It must run with JAX enabled —
+  # PYAUTO_DISABLE_JAX=1 would silently flip use_jax flags off and the
+  # script would no-op.
+  - pattern: "imaging/visualization_jax"
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_lp"
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_mge"

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -7,16 +7,13 @@ Pilot for https://github.com/PyAutoLabs/PyAutoFit/issues/1227.
 Goal
 ----
 Run ``VisualizerImaging.visualize`` with JAX enabled end-to-end, gated behind
-the new ``use_jax_for_visualization`` flag on ``Analysis``. The parametric MGE
-source is used deliberately (simplest case — no pixelization, no inversion).
-
-This is **Path C** from the plan: ``fit_from`` runs on the eager JAX path
-(``use_jax=True`` makes ``_xp`` be ``jnp``) and returns a ``FitImaging``
-backed by ``jax.Array`` objects. Matplotlib-bound plotters materialise arrays
-to NumPy at the boundary. No ``jax.jit`` is applied to ``fit_from`` — the
-full-JIT path (Path A) depends on ``FitImaging`` itself becoming a pytree,
-which is tracked as a separate task (see
-``PyAutoPrompt/issued/fit_imaging_pytree.md``).
+``use_jax_for_visualization=True`` on ``Analysis``. After PyAutoLens #443
+(2026-04-19) the imaging visualizer dispatches through
+``analysis.fit_for_visualization``, which lazily wraps ``fit_from`` in
+``jax.jit``. To trace across that boundary the model and fit return type
+must be JAX pytrees, so this script enables pytree registration before
+constructing the model. Parametric MGE source — simplest case (no
+pixelization, no inversion).
 
 Scope
 -----
@@ -28,7 +25,6 @@ Scope
 """
 
 import shutil
-import traceback
 from os import path
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,7 +38,10 @@ conf.instance.push(
 
 import autofit as af
 import autolens as al
+from autofit.jax.pytrees import enable_pytrees, register_model
 from autolens.imaging.model.visualizer import VisualizerImaging
+
+enable_pytrees()
 
 
 """
@@ -103,6 +102,8 @@ source = af.Model(al.Galaxy, redshift=1.0, bulge=source_bulge)
 
 model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
 
+register_model(model)
+
 
 """
 __Analysis__
@@ -137,19 +138,13 @@ __Run visualize on the eager-JAX fit__
 instance = model.instance_from_prior_medians()
 
 print("Running VisualizerImaging.visualize with use_jax_for_visualization=True ...")
-try:
-    VisualizerImaging.visualize(
-        analysis=analysis,
-        paths=paths,
-        instance=instance,
-        during_analysis=False,
-    )
-    assert (image_path / "parametric" / "fit.png").exists() or (
-        image_path / "fit.png"
-    ).exists(), "fit.png was not produced"
-    print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/tracer.png.")
-except Exception:
-    print("PILOT FAILED — traceback below:")
-    print("=" * 72)
-    traceback.print_exc()
-    print("=" * 72)
+VisualizerImaging.visualize(
+    analysis=analysis,
+    paths=paths,
+    instance=instance,
+    during_analysis=False,
+)
+assert (image_path / "parametric" / "fit.png").exists() or (
+    image_path / "fit.png"
+).exists(), "fit.png was not produced"
+print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/tracer.png.")


### PR DESCRIPTION
## Summary

`scripts/imaging/visualization_jax.py` was silently broken under JAX since PyAutoLens #443 (2026-04-19) made `VisualizerImaging.visualize` dispatch through `analysis.fit_for_visualization` (which JITs `fit_from`). Without `enable_pytrees()` + `register_model(model)`, `jax.jit(fit_from)` cannot trace the `ModelInstance` argument and raises `TypeError`. The script's `try/except` wrapper caught the failure, printed "PILOT FAILED", and exited 0 — so test runners never noticed.

This PR adds the two missing calls, drops the swallowed-exception pattern so future regressions fail loud, and splits the `imaging/visualization` env_vars override into a NumPy-only entry and a JAX-only entry that unsets `PYAUTO_DISABLE_JAX`, mirroring the existing `imaging/modeling_visualization_jit` override.

Sibling PR in autogalaxy_workspace_test fixes the same latent bug on the autogalaxy side (broken since PyAutoGalaxy #390 on 2026-05-08).

Closes #84.

## Scripts Changed

- `scripts/imaging/visualization_jax.py` — add `enable_pytrees()` + `register_model(model)`; drop `try/except` wrapper; update docstring to reflect the Path-A (jit-traced) intent
- `config/build/env_vars.yaml` — split `imaging/visualization` override; add `imaging/visualization_jax` entry that unsets `PYAUTO_DISABLE_JAX`

## Test Plan

- [x] `python scripts/imaging/visualization_jax.py` (with JAX enabled) — `PILOT SUCCEEDED — JAX-backed visualization produced fit.png/tracer.png.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)