### PR TITLE
fix(interferometer): migrate sparse-operator call to new curvature API

### DIFF
--- a/notebooks/jax_likelihood_functions/interferometer/rectangular_sparse.ipynb
+++ b/notebooks/jax_likelihood_functions/interferometer/rectangular_sparse.ipynb
@@ -333,7 +333,7 @@
         "\n",
         "np.testing.assert_allclose(\n",
         "    np.array(result),\n",
-        "    -3152.03184792,\n",
+        "    -3164.286252,\n",
         "    rtol=1e-4,\n",
         "    err_msg=\"interferometer/rectangular_sparse: JAX vmap likelihood mismatch\",\n",
         ")\n"

--- a/scripts/jax_assertions/sparse_operators.py
+++ b/scripts/jax_assertions/sparse_operators.py
@@ -235,18 +235,29 @@ pix_indexes_for_sub_slim_index = np.array([[0], [2], [1], [1], [2], [2], [0], [2
 
 pix_weights_for_sub_slim_index = np.ones(shape=(9, 1))
 
+# Use the unmasked-extent index for the interferometer sparse operator (which
+# lives on the extent grid, not the full native grid). For this fully-unmasked
+# 3x3 grid the two indices are identical, but the extent form is the convention
+# accepted by the operator after the Pmax > 1 fix.
+rows_interferometer, cols_interferometer, vals_interferometer = aa.util.mapper.sparse_triplets_from(
+    pix_indexes_for_sub=pix_indexes_for_sub_slim_index,
+    pix_weights_for_sub=pix_weights_for_sub_slim_index,
+    slim_index_for_sub=np.arange(pix_indexes_for_sub_slim_index.shape[0], dtype=np.int32),
+    fft_index_for_masked_pixel=grid.mask.extent_index_for_masked_pixel,
+    sub_fraction_slim=np.ones(pix_indexes_for_sub_slim_index.shape[0], dtype=np.float64),
+    return_rows_slim=False,
+)
+
 sparse_operator = aa.InterferometerSparseOperator.from_nufft_precision_operator(
     nufft_precision_operator=nufft_precision_operator,
     dirty_image=None,
 )
 
-curvature_matrix_via_preload = (
-    sparse_operator.curvature_matrix_via_sparse_operator_from(
-        pix_indexes_for_sub_slim_index=pix_indexes_for_sub_slim_index,
-        pix_weights_for_sub_slim_index=pix_weights_for_sub_slim_index,
-        fft_index_for_masked_pixel=grid.mask.fft_index_for_masked_pixel,
-        pix_pixels=3,
-    )
+curvature_matrix_via_preload = sparse_operator.curvature_matrix_diag_from(
+    rows=rows_interferometer,
+    cols=cols_interferometer,
+    vals=vals_interferometer,
+    S=3,
 )
 
 npt.assert_allclose(

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
@@ -213,7 +213,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 
 np.testing.assert_allclose(
     np.array(result),
-    -3152.03184792,
+    -3164.286252,
     rtol=1e-4,
     err_msg="interferometer/rectangular_sparse: JAX vmap likelihood mismatch",
 )
@@ -263,12 +263,12 @@ __Path B: TransformerDFT, no sparse operator__
 The Path A run above uses TransformerDFT + `apply_sparse_operator(use_jax=True)`
 (the cached-precision-matrix accelerator for pixelization). This pass uses
 the same TransformerDFT but skips the sparse-operator optimization — the
-plain direct-DFT pixelization path. The two paths give *different*
-log-likelihoods at the ~0.4% level because the sparse-operator
-precomputation is a numerical reformulation, not an exact reproduction;
-this is expected. Path B's literal must therefore match
-`scripts/jax_likelihood_functions/interferometer/rectangular.py` (which is
-the same model + DFT-no-sparse path).
+plain direct-DFT pixelization path. After the Pmax > 1 / extent-indexing fix
+(issue #314), the two paths agree to numerical precision: the sparse-operator
+precomputation is mathematically exact, not a "numerical reformulation".
+Path B's literal therefore matches Path A and
+`scripts/jax_likelihood_functions/interferometer/rectangular.py` (the same
+model + DFT-no-sparse path).
 """
 dataset_dft_nosparse = al.Interferometer.from_fits(
     data_path=path.join(dataset_path, "data.fits"),


### PR DESCRIPTION
## Summary

Workspace half of [PyAutoLabs/PyAutoArray#316](https://github.com/PyAutoLabs/PyAutoArray/pull/316). That library PR closes the silent ~34% Frobenius mismatch on `Interferometer + Delaunay + apply_sparse_operator` (issue Jammy2211/PyAutoArray#314) and the previously-documented ~0.4% Pmax = 1 "numerical reformulation" gap. Both reduce to the same extent-vs-native indexing bug — the library fix is detailed in #316.

This PR migrates the one direct caller of the renamed library API in `autolens_workspace_test`, and updates the now-stale Pmax = 1 likelihood literal.

## Library Dependency

**This PR MUST NOT be merged before PyAutoLabs/PyAutoArray#316 lands on `main`.** It depends on two new symbols in #316:

- `InterferometerSparseOperator.curvature_matrix_diag_from(rows, cols, vals, *, S)` — replaces the removed `curvature_matrix_via_sparse_operator_from`.
- `Mask2D.extent_index_for_masked_pixel` — slim → unmasked-extent-flat index, used to build the triplets.

Merging this before #316 would break `autolens_workspace_test` on `main`.

## Scripts Changed

- `scripts/jax_assertions/sparse_operators.py` — migrated the Pmax = 1 `InterferometerSparseOperator` parity check from the old `curvature_matrix_via_sparse_operator_from(pix_indexes_for_sub_slim_index, pix_weights_for_sub_slim_index, pix_pixels, fft_index_for_masked_pixel)` signature to the new `curvature_matrix_diag_from(rows, cols, vals, S)` signature. Triplets are built via `aa.util.mapper.sparse_triplets_from(..., fft_index_for_masked_pixel=grid.mask.extent_index_for_masked_pixel, return_rows_slim=False)` — extent-flat indexing, matching the imaging Pmax=1 call site immediately above in the same file.
- `scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py` — Path A `fitness._vmap` likelihood literal `-3152.03184792` → `-3164.286252`. The new value matches the Path B (TransformerDFT-no-sparse) and Path C (TransformerNUFFT-no-sparse) literals exactly: with the indexing fix, all three paths agree to ~1e-13. The Path B docstring's "the two paths give different log-likelihoods at the ~0.4% level because the sparse-operator precomputation is a numerical reformulation" was a rationalization of the now-fixed bug; it's been replaced with the correct description (the sparse path is mathematically exact, agrees to ~1e-13).
- `notebooks/jax_likelihood_functions/interferometer/rectangular_sparse.ipynb` — surgical 1-line literal update mirroring the script.

## Upstream PR

- https://github.com/PyAutoLabs/PyAutoArray/pull/316

## Test plan

- [x] `python scripts/jax_assertions/sparse_operators.py` → "all assertions passed" (Pmax=1 PSF-weighted-noise reference still matches at rtol=1e-4).
- [x] `python scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py` → all three paths converge to `-3164.286252`, all assertions pass.
- [ ] /smoke_test → no regressions in unrelated workspace_test scripts.

Tracks Jammy2211/PyAutoArray#314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)