### PR TITLE
tests: JAX JIT coverage for ag.mp.ExternalPotential

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ There are four layers of JAX integration testing, each targeting a different lev
 4. **`profiles_jit.py`** — lowest level.  Tests individual light profile
    `image_2d_from` and mass profile `deflections_yx_2d_from` / `convergence_2d_from`
    methods under JAX JIT.  Covers `lp.Sersic`, `lp.Exponential`, `lp.Gaussian`,
-   `lp.DevVaucouleurs`, `mp.Isothermal`, `mp.PowerLaw`, `mp.NFW`, `mp.ExternalShear`.
+   `lp.DevVaucouleurs`, `mp.Isothermal`, `mp.PowerLaw`, `mp.NFW`, `mp.ExternalShear`,
+   `mp.ExternalPotential`.
 
 ## Line Endings — Always Unix (LF)
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -165,7 +165,7 @@ targets the methods that are called internally by `LensCalc` and `Tracer`.
 **Light profiles**: `lp.Sersic`, `lp.Exponential`, `lp.Gaussian`, `lp.DevVaucouleurs`
 → `image_2d_from`
 
-**Mass profiles**: `mp.Isothermal`, `mp.PowerLaw`, `mp.NFW`, `mp.ExternalShear`
+**Mass profiles**: `mp.Isothermal`, `mp.PowerLaw`, `mp.NFW`, `mp.ExternalShear`, `mp.ExternalPotential`
 → `deflections_yx_2d_from`, `convergence_2d_from`
 
 Each method is tested on both `Grid2DIrregular` and `Grid2D.uniform`.

--- a/scripts/profiles_jit.py
+++ b/scripts/profiles_jit.py
@@ -45,6 +45,7 @@ Mass:
   - ag.mp.PowerLaw        → deflections_yx_2d_from, convergence_2d_from
   - ag.mp.NFW             → deflections_yx_2d_from, convergence_2d_from
   - ag.mp.ExternalShear   → deflections_yx_2d_from, convergence_2d_from
+  - ag.mp.ExternalPotential → deflections_yx_2d_from, convergence_2d_from
 """
 
 import jax
@@ -88,6 +89,7 @@ def check_profile_method(
     np_type,
     jax_type,
     rtol: float = 1e-5,
+    atol: float = 0.0,
 ):
     """
     Run the three-step JAX-JIT check for one profile method on one grid.
@@ -108,6 +110,11 @@ def check_profile_method(
         Expected autoarray type on the JAX path (outside JIT).
     rtol
         Relative tolerance for the NumPy vs JAX numerical comparison.
+    atol
+        Absolute tolerance for the NumPy vs JAX numerical comparison. Needed
+        for profiles whose output legitimately crosses zero on a grid point
+        (e.g. ``mp.ExternalPotential`` convergence on the τ-null line), where
+        the rtol-only check blows up on sub-machine-precision reductions.
     """
     method = getattr(profile, method_name)
 
@@ -144,6 +151,7 @@ def check_profile_method(
         np.array(result_jax_jit),
         np.array(result_np._array),
         rtol=rtol,
+        atol=atol,
         err_msg=f"{label}: numpy vs jax (jit) mismatch",
     )
 
@@ -601,5 +609,55 @@ for method_name, np_irr, jax_irr, np_uni, jax_uni in [
     )
 
 print("  mp.ExternalShear OK")
+
+"""
+ag.mp.ExternalPotential
+"""
+external_potential = ag.mp.ExternalPotential(
+    centre=(0.1, 0.2),
+    gamma_1=0.05,
+    gamma_2=0.03,
+    tau_1=0.02,
+    tau_2=-0.01,
+    delta_1=0.015,
+    delta_2=0.01,
+)
+
+for method_name, np_irr, jax_irr, np_uni, jax_uni in [
+    (
+        "deflections_yx_2d_from",
+        aa.VectorYX2DIrregular,
+        aa.VectorYX2DIrregular,
+        aa.VectorYX2D,
+        aa.VectorYX2D,
+    ),
+    (
+        "convergence_2d_from",
+        aa.ArrayIrregular,
+        aa.ArrayIrregular,
+        aa.Array2D,
+        aa.Array2D,
+    ),
+]:
+    check_profile_method(
+        label=f"mp.ExternalPotential.{method_name} (irregular)",
+        profile=external_potential,
+        method_name=method_name,
+        grid=grid_irr,
+        np_type=np_irr,
+        jax_type=jax_irr,
+        atol=1e-12,
+    )
+    check_profile_method(
+        label=f"mp.ExternalPotential.{method_name} (uniform)",
+        profile=external_potential,
+        method_name=method_name,
+        grid=grid_uni,
+        np_type=np_uni,
+        jax_type=jax_uni,
+        atol=1e-12,
+    )
+
+print("  mp.ExternalPotential OK")
 
 print("\nAll profiles_jit.py checks passed.")


### PR DESCRIPTION
## Summary
Follow-up to PyAutoLabs/PyAutoGalaxy#422. Adds JAX JIT parity coverage for `ag.mp.ExternalPotential` in `scripts/profiles_jit.py`, parallel to the existing `ExternalShear` block.

- New `ExternalPotential` block at the bottom of the mass-profile section, testing `deflections_yx_2d_from` and `convergence_2d_from` on both `Grid2DIrregular` and `Grid2D.uniform` with the three-step pattern (NumPy → JAX outer → JAX JIT).
- Test instance uses non-zero `centre=(0.1, 0.2)`, all six component params non-zero — exercises every term plus the centre-shift through `@aa.decorators.transform`.

## API Changes
Internal-only helper signature change: `check_profile_method` now accepts an `atol` kwarg (default `0.0`). Existing callers unchanged. See full details below.

## Test Plan
- [ ] `python scripts/profiles_jit.py` — prints `mp.ExternalPotential OK` and `All profiles_jit.py checks passed.` (verified locally).

## Notes
The `atol` kwarg was needed because `ExternalPotential`'s convergence formula `κ(x, y) = τ₁·x + τ₂·y` legitimately crosses zero on the τ-null line. The 5×5 uniform test grid lands one point close to that line where numpy and jax reductions of the linear combination differ at machine precision (~2e-19). With `rtol=1e-5` the relative tolerance collapses to ~1e-24 near zero and the test fails on a difference smaller than `eps`. Passing `atol=1e-12` puts a sub-physical absolute floor under the comparison — well below any meaningful signal but well above fp noise.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- New ExternalPotential block in `scripts/profiles_jit.py` (covers `deflections_yx_2d_from`, `convergence_2d_from` on irregular and uniform grids, three-step JAX pattern, `atol=1e-12`).

### Changed Signature
- `scripts/profiles_jit.py::check_profile_method` — added `atol: float = 0.0` kwarg, threaded to `npt.assert_allclose`. Existing call sites that don't pass `atol` are unaffected.

### Removed
None.

### Migration
None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)