### PR TITLE
test: add __Likelihood Sanity__ blocks to pixelization scripts

### DIFF
--- a/scripts/imaging/model_fit.py
+++ b/scripts/imaging/model_fit.py
@@ -172,12 +172,66 @@ analysis = al.AnalysisImaging(
 )
 
 """
+__Likelihood Sanity__
+
+Guard against regressions like PyAutoLens PR #504, where the CPU branch of
+``AnalysisImaging.log_likelihood_function`` silently returned ``fit.log_likelihood``
+instead of ``fit.figure_of_merit``. For a pixelization source these differ by
+the regularization log-det terms of the Bayesian log evidence, so a nested
+sampler would drift to ``outer_coefficient ~= 0`` instead of the physical
+Bayesian maximum.
+
+The sanity analysis is built without ``positions_likelihood_list`` so there is
+no ``log_likelihood_penalty`` term to subtract from the comparison.
+"""
+import pytest
+from autofit.non_linear.fitness import Fitness
+
+
+def _assert_likelihood_sanity(label, analysis, model):
+    instance = model.instance_from_prior_medians()
+    analysis_value = analysis.log_likelihood_function(instance=instance)
+    fit = analysis.fit_from(instance=instance)
+    assert float(analysis_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: log_likelihood_function ({analysis_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit}) — regression of PR #504"
+    )
+    assert float(fit.figure_of_merit) != pytest.approx(
+        float(fit.log_likelihood), rel=1e-6
+    ), (
+        f"{label}: figure_of_merit == log_likelihood — pixelization regularization "
+        f"log-det terms are zero, this script no longer exercises the bug PR #504 fixed"
+    )
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        paths=None,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+    call_wrap_value = fitness.call_wrap(model.physical_values_from_prior_medians)
+    assert float(call_wrap_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: Fitness.call_wrap ({call_wrap_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit})"
+    )
+    print(f"  PASS {label}: LLF == figure_of_merit != log_likelihood == call_wrap")
+
+
+sanity_analysis_cpu = al.AnalysisImaging(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    use_jax=False,
+)
+_assert_likelihood_sanity("CPU", sanity_analysis_cpu, model)
+
+
+"""
 __Model-Fit__
 
 We can now begin the model-fit by passing the model and analysis object to the search, which performs a non-linear
 search to find which models fit the data with the highest likelihood.
 
-Checkout the output folder for live outputs of the results of the fit, including on-the-fly visualization of the best 
+Checkout the output folder for live outputs of the results of the fit, including on-the-fly visualization of the best
 fit model!
 """
 result = search.fit(model=model, analysis=analysis)

--- a/scripts/imaging/modeling_visualization_jit_delaunay.py
+++ b/scripts/imaging/modeling_visualization_jit_delaunay.py
@@ -181,6 +181,63 @@ analysis_probe = al.AnalysisImaging(
 
 instance_probe = model.instance_from_prior_medians()
 
+
+"""
+__Likelihood Sanity__
+
+Guard against regressions like PyAutoLens PR #504, where the CPU branch of
+``AnalysisImaging.log_likelihood_function`` silently returned ``fit.log_likelihood``
+instead of ``fit.figure_of_merit``. For a pixelization source these differ by
+the regularization log-det terms of the Bayesian log evidence, so a nested
+sampler would drift to ``outer_coefficient ~= 0`` instead of the physical
+Bayesian maximum.
+
+Both backends (CPU + JAX) are checked: the bug only fired on the CPU branch
+historically, but the guard catches future drift in either direction.
+"""
+import pytest
+from autofit.non_linear.fitness import Fitness
+
+
+def _assert_likelihood_sanity(label, analysis, model):
+    instance = model.instance_from_prior_medians()
+    analysis_value = analysis.log_likelihood_function(instance=instance)
+    fit = analysis.fit_from(instance=instance)
+    assert float(analysis_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: log_likelihood_function ({analysis_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit}) — regression of PR #504"
+    )
+    assert float(fit.figure_of_merit) != pytest.approx(
+        float(fit.log_likelihood), rel=1e-6
+    ), (
+        f"{label}: figure_of_merit == log_likelihood — pixelization regularization "
+        f"log-det terms are zero, this script no longer exercises the bug PR #504 fixed"
+    )
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        paths=None,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+    call_wrap_value = fitness.call_wrap(model.physical_values_from_prior_medians)
+    assert float(call_wrap_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: Fitness.call_wrap ({call_wrap_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit})"
+    )
+    print(f"  PASS {label}: LLF == figure_of_merit != log_likelihood == call_wrap")
+
+
+sanity_analysis_cpu = al.AnalysisImaging(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    use_jax=False,
+)
+_assert_likelihood_sanity("CPU", sanity_analysis_cpu, model)
+_assert_likelihood_sanity("JAX", analysis_probe, model)
+
+
 t0 = time.perf_counter()
 fit_1 = analysis_probe.fit_for_visualization(instance_probe)
 jax.block_until_ready(fit_1.log_likelihood)

--- a/scripts/imaging/modeling_visualization_jit_rectangular.py
+++ b/scripts/imaging/modeling_visualization_jit_rectangular.py
@@ -165,6 +165,67 @@ analysis_probe = al.AnalysisImaging(
 
 instance_probe = model.instance_from_prior_medians()
 
+
+"""
+__Likelihood Sanity__
+
+Guard against regressions like PyAutoLens PR #504, where the CPU branch of
+``AnalysisImaging.log_likelihood_function`` silently returned ``fit.log_likelihood``
+instead of ``fit.figure_of_merit``. For a pixelization source these differ by
+the regularization log-det terms of the Bayesian log evidence, so a nested
+sampler would drift to ``outer_coefficient ~= 0`` instead of the physical
+Bayesian maximum.
+
+Both backends (CPU + JAX) are checked: the bug only fired on the CPU branch
+historically, but the guard catches future drift in either direction.
+"""
+import pytest
+from autofit.non_linear.fitness import Fitness
+
+
+def _assert_likelihood_sanity(label, analysis, model):
+    instance = model.instance_from_prior_medians()
+    analysis_value = analysis.log_likelihood_function(instance=instance)
+    fit = analysis.fit_from(instance=instance)
+    assert float(analysis_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: log_likelihood_function ({analysis_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit}) — regression of PR #504"
+    )
+    assert float(fit.figure_of_merit) != pytest.approx(
+        float(fit.log_likelihood), rel=1e-6
+    ), (
+        f"{label}: figure_of_merit == log_likelihood — pixelization regularization "
+        f"log-det terms are zero, this script no longer exercises the bug PR #504 fixed"
+    )
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        paths=None,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+    call_wrap_value = fitness.call_wrap(model.physical_values_from_prior_medians)
+    assert float(call_wrap_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: Fitness.call_wrap ({call_wrap_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit})"
+    )
+    print(f"  PASS {label}: LLF == figure_of_merit != log_likelihood == call_wrap")
+
+
+sanity_analysis_cpu = al.AnalysisImaging(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    raise_inversion_positions_likelihood_exception=False,
+    settings=al.Settings(
+        use_border_relocator=True,
+        use_positive_only_solver=True,
+    ),
+    use_jax=False,
+)
+_assert_likelihood_sanity("CPU", sanity_analysis_cpu, model)
+_assert_likelihood_sanity("JAX", analysis_probe, model)
+
+
 t0 = time.perf_counter()
 fit_1 = analysis_probe.fit_for_visualization(instance_probe)
 jax.block_until_ready(fit_1.log_likelihood)

--- a/scripts/interferometer/model_fit.py
+++ b/scripts/interferometer/model_fit.py
@@ -168,12 +168,67 @@ analysis = al.AnalysisInterferometer(
 )
 
 """
+__Likelihood Sanity__
+
+Mirror of the imaging guard against regressions like PyAutoLens PR #504, where
+the CPU branch of ``AnalysisImaging.log_likelihood_function`` silently returned
+``fit.log_likelihood`` instead of ``fit.figure_of_merit``. The interferometer
+analysis returns ``figure_of_merit`` correctly today, but this guard catches
+the same asymmetry from being introduced here in future.
+
+For a pixelization source ``figure_of_merit`` and ``log_likelihood`` differ by
+the regularization log-det terms of the Bayesian log evidence. The sanity
+analysis is built without ``positions_likelihood_list`` so there is no
+``log_likelihood_penalty`` term to subtract from the comparison.
+"""
+import pytest
+from autofit.non_linear.fitness import Fitness
+
+
+def _assert_likelihood_sanity(label, analysis, model):
+    instance = model.instance_from_prior_medians()
+    analysis_value = analysis.log_likelihood_function(instance=instance)
+    fit = analysis.fit_from(instance=instance)
+    assert float(analysis_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: log_likelihood_function ({analysis_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit}) — regression of PR #504"
+    )
+    assert float(fit.figure_of_merit) != pytest.approx(
+        float(fit.log_likelihood), rel=1e-6
+    ), (
+        f"{label}: figure_of_merit == log_likelihood — pixelization regularization "
+        f"log-det terms are zero, this script no longer exercises the bug PR #504 fixed"
+    )
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        paths=None,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+    call_wrap_value = fitness.call_wrap(model.physical_values_from_prior_medians)
+    assert float(call_wrap_value) == pytest.approx(float(fit.figure_of_merit)), (
+        f"{label}: Fitness.call_wrap ({call_wrap_value}) does not match "
+        f"fit.figure_of_merit ({fit.figure_of_merit})"
+    )
+    print(f"  PASS {label}: LLF == figure_of_merit != log_likelihood == call_wrap")
+
+
+sanity_analysis_cpu = al.AnalysisInterferometer(
+    dataset=dataset,
+    adapt_images=adapt_images,
+    use_jax=False,
+)
+_assert_likelihood_sanity("CPU", sanity_analysis_cpu, model)
+
+
+"""
 __Model-Fit__
 
 We can now begin the model-fit by passing the model and analysis object to the search, which performs a non-linear
 search to find which models fit the data with the highest likelihood.
 
-Checkout the output folder for live outputs of the results of the fit, including on-the-fly visualization of the best 
+Checkout the output folder for live outputs of the results of the fit, including on-the-fly visualization of the best
 fit model!
 """
 result = search.fit(model=model, analysis=analysis)


### PR DESCRIPTION
## Summary
Adds `__Likelihood Sanity__` regression-guard blocks before the Nautilus search in every integration script that fits a pixelization source. Each block builds the prior-median instance, calls `analysis.log_likelihood_function`, reconstructs the equivalent fit via `analysis.fit_from`, and asserts:

- `log_likelihood_function == fit.figure_of_merit` — catches the PR #504 pattern (returning `fit.log_likelihood` instead of `fit.figure_of_merit`)
- `fit.figure_of_merit != fit.log_likelihood` — kills tautological pass on a pixelization-less model
- `Fitness.call_wrap == fit.figure_of_merit` — guards the Nautilus-facing surface (parameter-vector → instance → figure-of-merit conversion)

The JIT scripts cover both backends (CPU + JAX) since the bug only fired on the CPU branch historically; the guard catches future drift in either direction. Non-JIT scripts cover CPU only.

## Scripts Changed
- `scripts/imaging/model_fit.py` — CPU-only block between `__Analysis__` and `__Model-Fit__` for the Isothermal + Delaunay pixelization model
- `scripts/imaging/modeling_visualization_jit_delaunay.py` — CPU + JAX block inside Part 1 of the PowerLaw + Delaunay JIT caching probe
- `scripts/imaging/modeling_visualization_jit_rectangular.py` — CPU + JAX block inside Part 1 of the PowerLaw + Rectangular JIT caching probe
- `scripts/interferometer/model_fit.py` — CPU-only block for `AnalysisInterferometer` + `FitInterferometer` with Isothermal + Delaunay pixelization

## Test Plan
- [ ] Smoke tests pass for autolens_workspace_test
- [ ] CI build server runs the modified scripts end-to-end and the new assertions pass on both CPU and JAX paths

Refs #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
