### PR TITLE
config(env_vars): repair FAST_PLOTS coverage for visualization scripts

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -6,7 +6,10 @@
 #
 # Pattern convention (same as no_run.yaml):
 #   - Patterns containing '/' do a substring match against the file path
-#   - Patterns without '/' match the file stem exactly
+#     including extension (so patterns may end in `.py` to anchor against
+#     the script form, e.g. `imaging/visualization.py` matches only the
+#     `.py` script, not `imaging/visualization_jax.py`).
+#   - Patterns without '/' match the file stem exactly.
 
 defaults:
   PYAUTO_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
@@ -35,14 +38,18 @@ overrides:
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "imaging/model_fit"
     unset: [PYAUTO_SMALL_DATASETS]
+  # imaging/visualization.py asserts subplot PNG / FITS files land on disk
+  # and loads pre-committed FITS at full resolution — both PYAUTO_FAST_PLOTS
+  # (which short-circuits savefig) and PYAUTO_SMALL_DATASETS must be unset.
   - pattern: "imaging/visualization.py"
-    unset: [PYAUTO_SMALL_DATASETS]
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # visualization_jax exercises the jit-cached fit_for_visualization path
   # (registered model + autoarray pytrees). It must run with JAX enabled —
   # PYAUTO_DISABLE_JAX=1 would silently flip use_jax flags off and the
-  # script would no-op.
+  # script would no-op. Also asserts fit.png on disk so PYAUTO_FAST_PLOTS
+  # must be unset.
   - pattern: "imaging/visualization_jax"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS]
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_lp"
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_mge"
@@ -51,11 +58,13 @@ overrides:
   # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
   - pattern: "model_composition/"
     unset: [PYAUTO_SMALL_DATASETS]
-  # visualization.py asserts subplot PNG files exist on disk, but
-  # PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray so
-  # no file is ever written.
+  # interferometer/visualization.py asserts subplot PNG / FITS files exist
+  # on disk (PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray)
+  # and loads pre-committed FITS at full resolution with an explicit
+  # (100, 100) shape_native mask — the 15x15 SMALL_DATASETS cap would still
+  # apply, so both must be unset.
   - pattern: "interferometer/visualization.py"
-    unset: [PYAUTO_FAST_PLOTS]
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # interferometer/visualization_jax exercises the jit-cached
   # fit_for_visualization path on the interferometer side. PYAUTO_DISABLE_JAX=1
   # would silently flip use_jax flags off — script needs JAX enabled.
@@ -80,10 +89,16 @@ overrides:
   # full resolution; just unset the cap.
   - pattern: "multi/visualization_imaging"
     unset: [PYAUTO_SMALL_DATASETS]
+  # point_source/visualization.py asserts fit.png lands on disk and uses a
+  # JSON point dataset (no FITS, no mask) — PYAUTO_FAST_PLOTS must be unset
+  # but PYAUTO_SMALL_DATASETS does not affect this script.
+  - pattern: "point_source/visualization.py"
+    unset: [PYAUTO_FAST_PLOTS]
   # point_source/visualization_jax exercises the jit-cached
-  # fit_for_visualization path on the point-source side.
+  # fit_for_visualization path on the point-source side. Also asserts
+  # fit.png on disk so PYAUTO_FAST_PLOTS must be unset.
   - pattern: "point_source/visualization_jax"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS]
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # point_source/modeling_visualization_jit — live Nautilus + JIT path.
   - pattern: "point_source/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]


### PR DESCRIPTION
## Summary
Several `env_vars.yaml` override entries were missing `PYAUTO_FAST_PLOTS` from their `unset:` list, so the build server kept `PYAUTO_FAST_PLOTS=1` set even for the visualization scripts that explicitly assert PNGs land on disk. `PYAUTO_FAST_PLOTS=1` short-circuits `subplot_save` / `save_figure` in PyAutoArray — no PNG ever written, assertions fail with "fit.png was not produced" / "dataset.png missing" (triage **Cluster A**, plus the parked 40d-old `imaging/visualization` NEEDS_FIX entry).

This PR closes the coverage gap for every affected script and adds a new override for `point_source/visualization.py` (which had no entry at all).

## Configs Changed
- `config/build/env_vars.yaml`:
  - Updated pattern-convention header comment to document `.py`-anchored patterns.
  - `imaging/visualization.py`: appended `PYAUTO_FAST_PLOTS` to `unset:` (was only unsetting `PYAUTO_SMALL_DATASETS`).
  - `interferometer/visualization.py`: appended `PYAUTO_SMALL_DATASETS` to `unset:` — script loads FITS at full res with an explicit `(100, 100)` `shape_native` mask, so the 15×15 cap mismatches even when `shape_native` is explicit.
  - `imaging/visualization_jax`: appended `PYAUTO_FAST_PLOTS` to `unset:`.
  - `point_source/visualization_jax`: appended `PYAUTO_FAST_PLOTS` to `unset:`.
  - Added new override for `point_source/visualization.py` → `unset: [PYAUTO_FAST_PLOTS]` (JSON dataset, no FITS, no mask — `PYAUTO_FAST_PLOTS` alone is sufficient).

## Upstream PR
PyAutoBuild #91 — depends on its `_pattern_matches` fix to make the existing `imaging/visualization.py` and `interferometer/visualization.py` overrides fire (previously dead because the matcher stripped `.py` from the path before substring matching).

## Test Plan
- [x] End-to-end smoke under autobuild-resolved env (full `build_env_for_script` pipeline, with PyAutoBuild #91 applied): all 5 affected scripts pass — imaging 64.1s, interferometer 69.5s, point_source 20.0s, point_source_jax 41.6s, imaging_jax 123.8s.
- [ ] `/smoke_test autolens_test` runs cleanly (visualization scripts are commented out in `smoke_tests.txt` for an unrelated bypass-mode issue, so this PR is not directly exercised by smoke).

Next triage cluster regen should clear the autolens entries of Cluster A and the parked `imaging/visualization` NEEDS_FIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)