### PR TITLE
fix(interferometer): shrink Delaunay Path B vmap to single sample to avoid OOM

### DIFF
--- a/scripts/jax_likelihood_functions/interferometer/delaunay.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay.py
@@ -304,7 +304,10 @@ fitness_nufft = Fitness(
     resample_figure_of_merit=-1.0e99,
 )
 
-result_nufft = fitness_nufft._vmap(parameters)
+# Path B's TransformerNUFFT JIT compilation peaks at ~15 GB on this corpus,
+# OOM-killing python on 15 GB-RAM machines. The cross-check only needs one
+# sample to prove NUFFT vs DFT agree, so restrict to parameters[:1] here.
+result_nufft = fitness_nufft._vmap(parameters[:1])
 print()
 print("TransformerNUFFT vmap result:", result_nufft)
 


### PR DESCRIPTION
## Summary

Single 4-line edit to `scripts/jax_likelihood_functions/interferometer/delaunay.py`. Path B (TransformerNUFFT cross-check, added 2026-05-10 in `d89db3e`) was OOM-killing python during JIT compilation on 15 GB-RAM machines — verified on both GPU and CPU via SIGKILL, with kernel logs showing `total-vm ~23 GB / RSS ~15 GB` at kill.

Restricting Path B's vmap to `parameters[:1]` (1 sample instead of `batch_size=3`) cuts JIT memory ~3× while preserving the cross-check semantics — one sample is sufficient to validate that the NUFFT path agrees with the DFT path. This matches the pattern already used in `scripts/jax_likelihood_functions/datacube/delaunay.py`, whose NUFFT cube cross-check uses `batch_size=1` and consequently does not OOM on the same hardware.

Path A (jit-wrapped `fit_from`) and the primary TransformerDFT vmap retain `batch_size=3` — those blocks were already passing.

## Scripts Changed

- `scripts/jax_likelihood_functions/interferometer/delaunay.py` — restrict Path B (TransformerNUFFT) vmap input from full `parameters` to `parameters[:1]`, with a 3-line comment explaining the memory reason.

## Triage cluster note

The other two scripts in the original 2026-05-20 Cluster F triage report were verified to already pass on current main with no edits required — the triage had aged out for those entries:

- `scripts/jax_likelihood_functions/imaging/rectangular_dspl.py` — passes (`-3797.73182794` matches expected)
- `scripts/jax_likelihood_functions/datacube/delaunay.py` — passes (both Path A and TransformerNUFFT cube cross-check)

## Test Plan

- [ ] Smoke tests pass for autolens_workspace_test
- [x] Manual: full script run on GPU returns PY_EXIT=0 with all three Path A/B/Cross-check assertions PASSing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)