### PR TITLE
fix(cluster): keep cluster viz grid full-extent under PYAUTO_SMALL_DATASETS=1

### DIFF
--- a/scripts/cluster/visualization.py
+++ b/scripts/cluster/visualization.py
@@ -401,7 +401,11 @@ print("\nRunning plot 3 — critical-curve overlay...")
 _t0 = time.perf_counter()
 
 lens_calc = al.LensCalc.from_tracer(tracer, use_multi_plane=True, plane_j=-1)
-viz_grid = al.Grid2D.uniform(shape_native=(200, 200), pixel_scales=0.5)
+# The cluster host's tangential critical curve sits at ~30-50"; the assertion below requires the
+# grid to extend past it. Opt out of PYAUTO_SMALL_DATASETS' 15x15 @ 0.6" shrink for this one grid.
+viz_grid = al.Grid2D.uniform(
+    shape_native=(200, 200), pixel_scales=0.5, respect_small_datasets=False
+)
 tangential_curves = lens_calc.tangential_critical_curve_list_from(grid=viz_grid)
 
 CURVE_COLOR = "#00FFFF"


### PR DESCRIPTION
## Summary
Pass `respect_small_datasets=False` to the `viz_grid` construction in `scripts/cluster/visualization.py`. The cluster's tangential critical curve falls at ~30-50" radius; the global `PYAUTO_SMALL_DATASETS=1` shrink would collapse the 100"x100" grid to (15, 15) @ 0.6" (~8" extent), placing the entire grid inside the curve and silently breaking the `tangential_curves recovered >= 1` assertion.

Triaged originally as a simulator regression / LensCalc multi-plane plumbing bug (Cluster H); verification on clean main showed both diagnoses were wrong. The actual fix is two library kwargs (already shipped) and this one-line script opt-out.

## Scripts Changed
- `scripts/cluster/visualization.py` — `viz_grid` passes `respect_small_datasets=False` plus a one-line comment explaining the constraint. No other change.

## Upstream PR
- PyAutoArray: https://github.com/PyAutoLabs/PyAutoArray/pull/327 (merged)
- PyAutoGalaxy: https://github.com/PyAutoLabs/PyAutoGalaxy/pull/431 (merged)

## Test Plan
- [x] Cluster smoke test: `env PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1 JAX_ENABLE_X64=True python3 scripts/cluster/visualization.py` recovers `tangential_curves recovered: 1 OK` and prints `All visualization assertions passed.`
- [x] `scripts/cluster/simulator.py` still passes under the same env (sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)