### PR TITLE
test(viz): __Visualization Sanity__ rollout across modeling_visualization_jit*.py

### DIFF
--- a/scripts/imaging/modeling_visualization_jit_delaunay.py
+++ b/scripts/imaging/modeling_visualization_jit_delaunay.py
@@ -268,6 +268,56 @@ print("PASS: Delaunay jit-cached fit_for_visualization works and is reused.")
 
 
 """
+__Visualization Sanity__
+
+Phase D.1 rollout of the Sanity-block pattern from PR #111. Guards
+against the silent-zero / collapsed-source / unconstrained-latent
+regression class on the JIT-cached visualization path, for the
+pixelization-source variant where the script's prior-median model is
+even less likely to produce strong-enough lensing than the parametric
+imaging case. Uses a deterministic SIE sanity tracer so the assertions
+are independent of the script's pixelization configuration.
+"""
+import time as _sanity_time
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (correctness): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+
+
+"""
 ============================================================================
 Part 2 — Live Nautilus quick-update with Delaunay pixelization
 ============================================================================

--- a/scripts/imaging/modeling_visualization_jit_rectangular.py
+++ b/scripts/imaging/modeling_visualization_jit_rectangular.py
@@ -256,6 +256,54 @@ print("PASS: rectangular jit-cached fit_for_visualization works and is reused.")
 
 
 """
+__Visualization Sanity__
+
+Phase D.1 rollout of the Sanity-block pattern from PR #111. Guards
+against the silent-zero / collapsed-source / unconstrained-latent
+regression class on the JIT-cached visualization path, for the
+pixelization-source variant. Uses a deterministic SIE sanity tracer
+so assertions are independent of the script's pixelization config.
+"""
+import time as _sanity_time
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (correctness): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+
+
+"""
 ============================================================================
 Part 2 — Live Nautilus quick-update with rectangular pixelization
 ============================================================================

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -172,6 +172,71 @@ print("PASS: MGE jit-cached fit_for_visualization works and is reused.")
 
 
 """
+__Visualization Sanity__
+
+Phase D.1 rollout. Guards both the lensing-side regression class (silent
+zero / collapsed source / unconstrained latent — PyAutoGalaxy abd7b717,
+PyAutoFit #1280, PyAutoGalaxy #433) AND the interferometer-specific
+failure mode where the NUFFT-via-JAX linear inversion silently returns
+zero / NaN model visibilities. Lensing assertions use a deterministic
+SIE sanity tracer; visibility assertions use the script's actual fit.
+"""
+import time as _sanity_time
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+# Lensing-side: SIE sanity tracer (independent of the script's MGE model).
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (lensing): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+# Perf — warm-call latency must be under 100 ms (closure cache hit).
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+
+# Interferometer-specific: `fit.model_data` (an aa.Visibilities — complex
+# array of model visibilities) must be finite + non-zero. Catches NUFFT /
+# linear-inversion collapse on the JAX path that would leave subplot_fit.png
+# cosmetically OK but the underlying visibilities all-zero.
+_mv = np.asarray(fit_2.model_data)
+assert np.isfinite(_mv).all(), "model_data (visibilities) have nan/inf — NUFFT/inversion collapse"
+assert float(np.abs(_mv).sum()) > 0.0, (
+    "model_data (visibilities) all-zero — NUFFT/inversion collapse"
+)
+print(
+    f"  PASS Visualization Sanity (interferometer): "
+    f"|model_data|.sum() = {float(np.abs(_mv).sum()):.4f}"
+)
+
+
+"""
 ============================================================================
 Part 2 — Live Nautilus quick-update with MGE linear light profiles
 ============================================================================

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -144,6 +144,60 @@ print("PASS: Point-source jit-cached fit_for_visualization works and is reused."
 
 
 """
+__Visualization Sanity__
+
+Phase D.1 rollout. SIE-tracer lensing-side check: non-empty tangential
+critical curve + finite positive Einstein radius + warm-call < 100 ms.
+Catches the silent-zero / cache-busting failure modes (PyAutoGalaxy
+abd7b717, PyAutoFit #1280, PyAutoGalaxy #433).
+
+No point-source-specific assertion on `fit.figure_of_merit` — the
+script's prior-median position can legitimately give chi² = -inf
+(positions outside the image-pair basin of the prior-median lens),
+which would make the assertion flaky.
+"""
+import time as _sanity_time
+import numpy as np  # not imported at module top in this script
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+# Lensing-side sanity (SIE tracer, independent of the script's lens model).
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (lensing): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+
+
+"""
 ============================================================================
 Part 2 — Live Nautilus quick-update
 ============================================================================


### PR DESCRIPTION
## Summary

Phase D.1 of `z_features/fast_visualization.md`. Rolls the `__Visualization Sanity__` block pattern from PR #111 (imaging pilot) out to the remaining JIT-cached visualization scripts in this repo. Each block guards against the silent-zero / cache-busting / deflection-collapse regression class on every dataset type that exercises the JIT-cached `fit_for_visualization` path.

Phase A is superseded; Phase B + C already shipped. After this lands, Phase D.2 follows for `visualization_jax*.py` scripts and the missing-dataset coverage (ellipse, weak lensing, quantity viz_jit).

## Scripts Changed

- `scripts/imaging/modeling_visualization_jit_delaunay.py` — `__Visualization Sanity__` block with SIE sanity tracer; assertions: 1+ tangential CC via `zero_contour`, finite positive Einstein radius, warm-call < 100 ms.
- `scripts/imaging/modeling_visualization_jit_rectangular.py` — identical Sanity block as delaunay (the pixelization mesh-class difference doesn't affect lensing latents).
- `scripts/interferometer/modeling_visualization_jit.py` — SIE Sanity block + interferometer-specific `fit.model_data` (complex visibilities) finite + non-zero assertion on the script's cached `fit_2`.
- `scripts/point_source/modeling_visualization_jit.py` — SIE Sanity block only (no script-specific FoM assertion — the point-source prior-median position can legitimately give chi² = -inf when outside the image-pair basin; the SIE lensing-side checks catch the deflection-collapse failure class anyway).

Block insertion point on every script: after the existing Part-1 caching probe `PASS` print, before the Part-2 Nautilus search docstring. All four blocks use `_sanity_*` prefixed local names so they don't collide with the script's existing variables.

## Test Plan

- [x] `point_source/modeling_visualization_jit.py` — full local run passed: `1 tangential CC, einstein_radius=1.1938, warm call 67.3 ms`.
- [x] `interferometer/modeling_visualization_jit.py` — full local run passed up to and through Sanity block: `1 tangential CC, einstein_radius=1.1938, warm call 63.7 ms, |model_data|.sum() = 20247.4135`. Part 2 Nautilus continued cleanly until I terminated for time.
- [x] `imaging/modeling_visualization_jit_delaunay.py` / `_rectangular.py` — Sanity block syntactically identical to the imaging pilot's (PR #111) and uses the same SIE tracer. Not validated end-to-end locally because Part 1's `cached_time < 0.5 * compile_time` assertion is a pre-existing fragility on pixelization scripts when cache speedup < 2x on CPU + small datasets. Build server `run_all_scripts.sh` (with full data) does see the expected speedup. The Sanity block runs after Part 1 PASS, so the assertion itself doesn't gate the Sanity logic — only my ability to validate locally.
- [ ] Workspace smoke tests via `/smoke_test autolens_workspace_test` (the smoke list doesn't include `modeling_visualization_jit*.py`; it tests other scripts to confirm no broader regression).
- [ ] CI `run_all_scripts.sh` after merge will exercise all four updated scripts end-to-end on the build server.

## Out of Scope (Phase D.2)

- `visualization_jax*.py` scripts (different code path — JAX-only validation, no Nautilus search).
- Missing-dataset coverage: ellipse / weak lensing / quantity `modeling_visualization_jit.py` don't exist yet.

Closes #112 (alongside the autogalaxy_workspace_test companion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
