### PR TITLE
test(viz): __Visualization Sanity__ rollout across visualization_jax*.py

### DIFF
--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -148,3 +148,52 @@ assert (image_path / "parametric" / "fit.png").exists() or (
     image_path / "fit.png"
 ).exists(), "fit.png was not produced"
 print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/tracer.png.")
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout of the Sanity-block pattern from PR #111 / #113.
+Same imaging-template SIE assertions as the modeling_visualization_jit
+variant — catches the silent-zero / cache-busting failure class on the
+single-shot JAX-backed visualization path. Uses a deterministic SIE
+tracer so assertions are independent of the script's specific model.
+"""
+import time as _sanity_time
+import numpy as _sanity_np
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (correctness): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -144,3 +144,64 @@ assert (image_path / "fit.png").exists(), "fit.png was not produced"
 print(
     "PILOT SUCCEEDED — JAX-backed interferometer visualization produced fit.png/tracer.png."
 )
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout. Lensing-side SIE Sanity (silent-zero / cache-busting
+regression class) plus interferometer-specific `fit.model_data` (complex
+visibilities) finite + non-zero on the script's actual fit.
+"""
+import time as _sanity_time
+import numpy as _sanity_np
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (lensing): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+
+# Interferometer-specific: model_data (complex Visibilities) finite + non-zero.
+_fit_for_vis = analysis.fit_from(instance=instance)
+_mv = _sanity_np.asarray(_fit_for_vis.model_data)
+assert _sanity_np.isfinite(_mv).all(), (
+    "fit.model_data (visibilities) have nan/inf — NUFFT/inversion collapse"
+)
+assert float(_sanity_np.abs(_mv).sum()) > 0.0, (
+    "fit.model_data (visibilities) all-zero — NUFFT/inversion collapse"
+)
+print(
+    f"  PASS Visualization Sanity (interferometer): "
+    f"|model_data|.sum() = {float(_sanity_np.abs(_mv).sum()):.4f}"
+)

--- a/scripts/point_source/visualization_jax.py
+++ b/scripts/point_source/visualization_jax.py
@@ -137,3 +137,50 @@ assert (
     image_path / "fit.png"
 ).exists(), f"fit.png was not produced. Files present: {list(image_path.iterdir())}"
 print("PILOT SUCCEEDED — JAX-backed point-source visualization produced fit.png.")
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout. SIE-tracer lensing-side check only — no
+point-source-specific FoM assertion (prior-median position can
+legitimately give chi² = -inf if outside the image-pair basin).
+"""
+import time as _sanity_time
+import numpy as _sanity_np
+from autogalaxy.operate.lens_calc import LensCalc as _SanityLensCalc
+
+_sanity_lens = al.Galaxy(
+    redshift=0.5,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0), einstein_radius=1.2, ell_comps=(0.1, 0.0)
+    ),
+)
+_sanity_source = al.Galaxy(redshift=1.0)
+_sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
+_sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
+
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+assert len(_tc_list) > 0, (
+    "no tangential critical curves returned by zero_contour — algorithmic "
+    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+)
+_er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
+assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (
+    f"Einstein radius via zero_contour returned {_er_sanity} — should be "
+    "finite and positive for the SIE sanity tracer (einstein_radius=1.2)"
+)
+print(
+    f"  PASS Visualization Sanity (lensing): "
+    f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
+)
+
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
+_t0 = _sanity_time.perf_counter()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_warm_dt = _sanity_time.perf_counter() - _t0
+assert _warm_dt < 0.1, (
+    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
+    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+)
+print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")


### PR DESCRIPTION
## Summary

Phase D.2.a of `z_features/fast_visualization.md`. Adds `__Visualization Sanity__` blocks to the three existing `visualization_jax*.py` scripts in this repo — the single-shot JAX-backed visualization path (no Nautilus search), companion code path to the `modeling_visualization_jit*.py` scripts covered in Phase D.1 (PR #113).

Each block is inserted at the **end** of the script (after the existing `PILOT SUCCEEDED` print) because these scripts have no Part-1/Part-2 split. Uses the same SIE-sanity-tracer + `LensCalc.from_tracer(...)` + 3-assertion shape proven in the imaging pilot (PR #111).

## Scripts Changed

- `scripts/imaging/visualization_jax.py` — SIE Sanity (1 tangential CC + finite positive Einstein radius + warm-call < 100 ms).
- `scripts/interferometer/visualization_jax.py` — SIE Sanity + interferometer-specific `fit.model_data` (complex Visibilities) finite + non-zero via `analysis.fit_from(instance=instance)`. Catches NUFFT / linear-inversion collapse independent of the SIE-tracer lensing-side checks.
- `scripts/point_source/visualization_jax.py` — SIE Sanity only. No script-specific FoM assertion — the prior-median position can legitimately give chi² = -inf when outside the image-pair basin (same reasoning as the Phase D.1 point_source block).

## Test Plan

- [x] `imaging/visualization_jax.py` — full local run passed: `1 tangential CC, einstein_radius=1.1938, warm call 90.6 ms`.
- [x] `interferometer/visualization_jax.py` — full local run passed: `1 tangential CC, einstein_radius=1.1938, warm call 98.6 ms, |model_data|.sum() = 11118.6110`.
- [x] `point_source/visualization_jax.py` — full local run passed: `1 tangential CC, einstein_radius=1.1938, warm call 88.8 ms`.
- [ ] Workspace smoke tests via `/smoke_test autolens_workspace_test` (smoke list doesn't include `visualization_jax*.py`; tests other scripts for broader regression check).
- [ ] CI `run_all_scripts.sh` after merge exercises all three updated scripts end-to-end.

## Out of Scope (Phase D.2.b)

- New `modeling_visualization_jit.py` + `visualization_jax.py` for autolens weak lensing (entire `scripts/weak/` directory missing).
- Same for autogalaxy ellipse (`modeling_visualization_jit.py` missing) and autogalaxy quantity (same gap).
- Any library code change.

Closes #114 (alongside the autogalaxy_workspace_test companion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
