### PR TITLE
chore: remove fit_quantity config entries

### DIFF
--- a/config/visualize/plots.yaml
+++ b/config/visualize/plots.yaml
@@ -61,9 +61,6 @@ fit_ellipse:                               # Settings for plots of ellipse fitti
   data_no_ellipse: true                    # Plot the data without the black data ellipses, which obscure noisy data?
   ellipse_residuals: true                  # Plot the residuals of the ellipse fit?
 
-fit_quantity:                              # Settings for plots of fit quantities (e.g. FitQuantity).
-  subplot_fit: true
-
 galaxies:                                  # Settings for plots of galaxies (e.g. Galaxies).
   subplot_galaxies: false                  # Plot subplot of all quantities in each galaxies group (e.g. images, convergence)?
   subplot_galaxy_images: false             # Plot subplot of the image of each galaxy in the model?

--- a/scripts/aggregator/config/visualize.yaml
+++ b/scripts/aggregator/config/visualize.yaml
@@ -21,8 +21,6 @@ plots:
     subplot_fit_dirty_images: true
     fits_dirty_images: true                 # output dirty_images.fits showing the dirty image, noise-map, model-data, resiual-map, normalized residual map and chi-squared map?
   fit_point_dataset: {}
-  fit_quantity:
-    subplot_fit: true
   galaxies:
     subplot_galaxies: true
     subplot_galaxy_images: true

--- a/scripts/imaging/config/visualize/plots.yaml
+++ b/scripts/imaging/config/visualize/plots.yaml
@@ -57,6 +57,3 @@ fit_ellipse:
   data: true
   data_no_ellipse: true
   ellipse_residuals: true
-
-fit_quantity:
-  subplot_fit: true

--- a/scripts/imaging/config_source/visualize/plots.yaml
+++ b/scripts/imaging/config_source/visualize/plots.yaml
@@ -57,6 +57,3 @@ fit_ellipse:
   data: false
   data_no_ellipse: false
   ellipse_residuals: false
-
-fit_quantity:
-  subplot_fit: false

--- a/scripts/interferometer/config/visualize/plots.yaml
+++ b/scripts/interferometer/config/visualize/plots.yaml
@@ -57,6 +57,3 @@ fit_ellipse:
   data: true
   data_no_ellipse: true
   ellipse_residuals: true
-
-fit_quantity:
-  subplot_fit: true

--- a/scripts/interferometer/config_source/visualize/plots.yaml
+++ b/scripts/interferometer/config_source/visualize/plots.yaml
@@ -57,6 +57,3 @@ fit_ellipse:
   data: false
   data_no_ellipse: false
   ellipse_residuals: false
-
-fit_quantity:
-  subplot_fit: false


### PR DESCRIPTION
## Summary

The `FitQuantity` / `AnalysisQuantity` stack has been archived in PyAutoGalaxy/PyAutoLens's `feature/archive-quantity-package` PRs. This workspace had six YAML files referencing the removed library section.

## Changes

Removed the `fit_quantity:` stanza from each of:

- `config/visualize/plots.yaml`
- `scripts/aggregator/config/visualize.yaml`
- `scripts/imaging/config/visualize/plots.yaml`
- `scripts/imaging/config_source/visualize/plots.yaml`
- `scripts/interferometer/config/visualize/plots.yaml`
- `scripts/interferometer/config_source/visualize/plots.yaml`

## Test plan

- [x] `grep -rE 'fit_quantity' . --include='*.yaml'` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)