### PR TITLE
fix(dataset): regenerate stale point_source/simple dataset

### DIFF
--- a/dataset/point_source/simple/point_dataset_positions_only.json
+++ b/dataset/point_source/simple/point_dataset_positions_only.json
@@ -2,10 +2,10 @@
     "type": "instance",
     "class_path": "autolens.point.dataset.PointDataset",
     "arguments": {
-        "time_delays": null,
-        "time_delays_noise_map": null,
         "redshift": null,
-        "name": "point_0",
+        "fluxes_noise_map": null,
+        "time_delays": null,
+        "fluxes": null,
         "positions_noise_map": {
             "type": "instance",
             "class_path": "autoarray.structures.arrays.irregular.ArrayIrregular",
@@ -20,7 +20,6 @@
                 }
             }
         },
-        "fluxes_noise_map": null,
         "positions": {
             "type": "instance",
             "class_path": "autoarray.structures.grids.irregular_2d.Grid2DIrregular",
@@ -29,18 +28,19 @@
                     "type": "ndarray",
                     "array": [
                         [
-                            1.0,
-                            0.0
+                            1.3726562500000001,
+                            0.9936739398630823
                         ],
                         [
-                            0.0,
-                            1.0
+                            -0.9460937500000001,
+                            -1.1578579226638823
                         ]
                     ],
                     "dtype": "float64"
                 }
             }
         },
-        "fluxes": null
+        "time_delays_noise_map": null,
+        "name": "point_0"
     }
 }

--- a/dataset/point_source/simple/tracer.json
+++ b/dataset/point_source/simple/tracer.json
@@ -2,11 +2,6 @@
     "type": "instance",
     "class_path": "autolens.lens.tracer.Tracer",
     "arguments": {
-        "cosmology": {
-            "type": "instance",
-            "class_path": "autogalaxy.cosmology.model.Planck15",
-            "arguments": {}
-        },
         "galaxies": {
             "type": "list",
             "values": [
@@ -20,6 +15,7 @@
                             "type": "instance",
                             "class_path": "autogalaxy.profiles.mass.total.isothermal.Isothermal",
                             "arguments": {
+                                "einstein_radius": 1.6,
                                 "ell_comps": {
                                     "type": "tuple",
                                     "values": [
@@ -27,7 +23,6 @@
                                         0.01
                                     ]
                                 },
-                                "einstein_radius": 1.6,
                                 "centre": {
                                     "type": "tuple",
                                     "values": [
@@ -48,6 +43,11 @@
                     }
                 }
             ]
+        },
+        "cosmology": {
+            "type": "instance",
+            "class_path": "autogalaxy.cosmology.model.Planck15",
+            "arguments": {}
         }
     }
 }


### PR DESCRIPTION
## Summary

The committed `dataset/point_source/simple/point_dataset_positions_only.json` (and paired `tracer.json`) held placeholder positions `[[1.0, 0.0], [0.0, 1.0]]` that **don't match what the current `PointSolver` actually produces** for the simulator's lens model. Re-running `scripts/jax_likelihood_functions/point_source/simulator.py` gives the real solved image-plane positions `[[1.37, 0.99], [-0.95, -1.16]]`.

## Why this caused CI to fail

With the stale positions, every `(data_position, model_position)` pair in `FitPositionsImagePairAll.all_permutations_log_likelihoods` sat ~10⁵σ apart (σ=0.005), so:

```
exp(log_p) = exp(-0.5 * chi²) ≈ exp(-50_000) → 0
log(sum(0 + 0 + 0)) = log(0) = -inf
```

`chi_squared` → `inf`, `log_likelihood` → `-inf`, which autofit's `Fitness` replaces with `resample_figure_of_merit = -1e+99`. That's the value that triggered `np.testing.assert_allclose(..., -83.38049778)` to fail with `Max absolute difference: 1.e+99`.

After regenerating the dataset, the real model-vs-data residuals sit at the expected scale and `point.py` returns `-83.38049778` as the rebaselined literal expects.

## Verification

- [x] Ran `scripts/jax_likelihood_functions/point_source/simulator.py` in a worktree
- [x] Confirmed `scripts/jax_likelihood_functions/point_source/point.py` returns `[-83.38049778]` and passes its assert
- [x] Confirmed numpy fit.log_likelihood (`-83.380...`) and jit fit.log_likelihood (`-83.380...`) round-trip match

## Out of scope (deeper concern)

The commit that introduced the placeholder values (`e888612 pre build` yesterday) shouldn't have. The `pre_build` flow either didn't actually re-run the simulator or seeded the JSON with fixture-style values somehow. That deserves a separate look — but this PR is just the data refresh to unblock CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)