### PR TITLE
docs: rename autolens_base_project → autolens_assistant in comment

### DIFF
--- a/scripts/database/scrape/scaling_relation.py
+++ b/scripts/database/scrape/scaling_relation.py
@@ -12,7 +12,7 @@ profile as a function of its luminosity:
 
 where `scaling_factor` and `scaling_exponent` are free parameters inferred by the
 non-linear search.  This is the same relational model API used in production group
-and cluster lens modeling (see `autolens_base_project/scripts/group.py`).
+and cluster lens modeling (see `autolens_assistant/scripts/group.py`).
 
 __Known issue__
 


### PR DESCRIPTION
## Summary

Mirror the upstream rename of \`PyAutoLabs/autolens_base_project\` → \`PyAutoLabs/autolens_assistant\`. Updates a single comment in \`scripts/database/scrape/scaling_relation.py\` that pointed at the old repo's \`scripts/group.py\` reference.

Companion PR: PyAutoLabs/autolens_assistant#4

## Test plan

- [x] \`grep -rIn autolens_base_project scripts/\` returns zero matches.
- [ ] The scaling-relation test continues to work (this is a comment-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)