### PR TITLE
fix: inject test_mode segment into aggregator result paths

### DIFF
--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -32,14 +32,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = al.m.MockSearch(
         samples=samples, result=al.m.MockResult(model=model, samples=samples)

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -32,14 +32,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = al.m.MockSearch(
         samples=samples, result=al.m.MockResult(model=model, samples=samples)

--- a/scripts/aggregator/tracer.py
+++ b/scripts/aggregator/tracer.py
@@ -32,14 +32,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = al.m.MockSearch(
         samples=samples, result=al.m.MockResult(model=model, samples=samples)


### PR DESCRIPTION
## Summary
Migration for [PyAutoFit #1292](https://github.com/PyAutoLabs/PyAutoFit/pull/1292), which makes `PYAUTO_TEST_MODE` namespace AutoFit output paths under `output/test_mode/...`. The aggregator integration tests hardcode `PYAUTO_TEST_MODE=1` inline and reconstruct the result directory by joining `conf.instance.output_path` with the database name — they need the `test_mode/` segment too, otherwise `add_directory` scrapes an empty bare path and `assert i == 2` fails.

## Scripts Changed
- `scripts/aggregator/fit_imaging.py` — added `"test_mode"` to `result_path` composition in `clean()` and `aggregator_from()` (2 sites)
- `scripts/aggregator/fit_interferometer.py` — same (2 sites)
- `scripts/aggregator/tracer.py` — same (2 sites)

## Upstream PR
https://github.com/PyAutoLabs/PyAutoFit/pull/1292

## Test Plan
- [x] All 3 scripts pass under `PYAUTO_TEST_MODE=2` with the worktree's modified autofit
- [x] `/smoke_test autolens_workspace_test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)