### PR TITLE
feat: mass profile self-consistency test suite

### DIFF
--- a/scripts/mass/dark.py
+++ b/scripts/mass/dark.py
@@ -1,0 +1,109 @@
+"""
+Mass Profile Self-Consistency: Dark Matter Profiles
+====================================================
+
+Verifies that dark matter mass profiles (NFW, gNFW, cNFW families)
+satisfy the fundamental lensing relations:
+
+    div(alpha) = 2 * kappa
+    grad(psi)  = alpha
+    lap(psi)   = 2 * kappa
+
+using numerical differentiation independent of the source code.
+
+MCR, Scatter, and Virial variants are skipped — they derive parameters from
+mass-concentration relations but delegate to the same underlying NFW/gNFW/cNFW
+math for deflections, convergence, and potential.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import autogalaxy as ag
+from mass.util import make_grid, run_all_checks, print_summary_table, get_tolerances
+
+"""
+__Setup__
+"""
+
+grid = make_grid()
+tol = get_tolerances()
+results = []
+
+"""
+__NFW Family__
+"""
+
+mp = ag.mp.NFW(
+    centre=(0.0, 0.0),
+    ell_comps=(0.08, 0.04),
+    kappa_s=0.07,
+    scale_radius=1.2,
+)
+results.append(run_all_checks("NFW", mp, grid, tol))
+
+mp = ag.mp.NFWSph(centre=(0.0, 0.0), kappa_s=0.07, scale_radius=1.2)
+results.append(run_all_checks("NFWSph", mp, grid, tol))
+
+"""
+__gNFW Family__
+"""
+
+mp = ag.mp.gNFW(
+    centre=(0.0, 0.0),
+    ell_comps=(0.08, 0.04),
+    kappa_s=0.06,
+    inner_slope=1.2,
+    scale_radius=1.1,
+)
+results.append(run_all_checks("gNFW", mp, grid, tol))
+
+mp = ag.mp.gNFWSph(
+    centre=(0.0, 0.0), kappa_s=0.06, inner_slope=1.2, scale_radius=1.1
+)
+results.append(run_all_checks("gNFWSph", mp, grid, tol))
+
+"""
+__cNFW Family__
+
+convergence_2d_from and potential_2d_from both return zeros.
+"""
+
+mp = ag.mp.cNFW(
+    centre=(0.0, 0.0),
+    ell_comps=(0.08, 0.04),
+    kappa_s=0.06,
+    scale_radius=1.2,
+    core_radius=0.015,
+)
+results.append(run_all_checks("cNFW", mp, grid, tol))
+
+mp = ag.mp.cNFWSph(
+    centre=(0.0, 0.0), kappa_s=0.06, scale_radius=1.2, core_radius=0.015
+)
+results.append(run_all_checks("cNFWSph", mp, grid, tol))
+
+"""
+__NFW Truncated__
+
+potential_2d_from returns zeros.
+"""
+
+mp = ag.mp.NFWTruncatedSph(
+    centre=(0.0, 0.0),
+    kappa_s=0.07,
+    scale_radius=1.2,
+    truncation_radius=3.0,
+)
+results.append(run_all_checks("NFWTruncatedSph", mp, grid, tol))
+
+"""
+__Summary__
+"""
+
+print("=" * 70)
+print("Dark Matter Profiles — Self-Consistency Results")
+print("=" * 70)
+print_summary_table(results)

--- a/scripts/mass/point.py
+++ b/scripts/mass/point.py
@@ -1,0 +1,87 @@
+"""
+Mass Profile Self-Consistency: Point Mass Profiles
+===================================================
+
+Verifies that point mass profiles (PointMass, SMBH, SMBHBinary) satisfy the
+fundamental lensing relations:
+
+    div(alpha) = 2 * kappa
+    grad(psi)  = alpha
+    lap(psi)   = 2 * kappa
+
+using numerical differentiation independent of the source code.
+
+Point masses are singular at the centre — the convergence is a delta function.
+We offset the profile centre from the grid centre so that no grid pixel sits
+on the singularity. The div(alpha) = 2*kappa check is only meaningful away
+from the singularity (where kappa ~ 0 everywhere), so it will show as a
+trivial PASS or SKIP depending on numerical noise.
+
+PointMass.potential_2d_from returns zeros (placeholder).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import autogalaxy as ag
+from mass.util import make_grid, run_all_checks, print_summary_table, get_tolerances
+
+"""
+__Setup__
+
+Offset the profile centre to (0.3, 0.3) so the singularity does not fall
+on any grid pixel (the grid is centred at the origin).
+"""
+
+grid = make_grid()
+tol = get_tolerances()
+results = []
+
+offset_centre = (0.3, 0.3)
+
+"""
+__PointMass__
+
+potential_2d_from returns zeros.
+"""
+
+mp = ag.mp.PointMass(centre=offset_centre, einstein_radius=0.8)
+results.append(run_all_checks("PointMass", mp, grid, tol))
+
+"""
+__SMBH__
+"""
+
+mp = ag.mp.SMBH(
+    centre=offset_centre,
+    mass=1.5e10,
+    redshift_object=0.5,
+    redshift_source=1.2,
+)
+results.append(run_all_checks("SMBH", mp, grid, tol))
+
+"""
+__SMBHBinary__
+"""
+
+mp = ag.mp.SMBHBinary(
+    centre=offset_centre,
+    separation=0.5,
+    angle_binary=45.0,
+    mass=1.0e10,
+    mass_ratio=1.5,
+    redshift_object=0.5,
+    redshift_source=1.2,
+)
+results.append(run_all_checks("SMBHBinary", mp, grid, tol))
+
+"""
+__Summary__
+"""
+
+print("=" * 70)
+print("Point Mass Profiles — Self-Consistency Results")
+print("=" * 70)
+print_summary_table(results)

--- a/scripts/mass/sheets.py
+++ b/scripts/mass/sheets.py
@@ -1,0 +1,79 @@
+"""
+Mass Profile Self-Consistency: Sheet / Perturbation Profiles
+=============================================================
+
+Verifies that sheet and external perturbation profiles (ExternalShear,
+MassSheet, ExternalPotential) satisfy the fundamental lensing relations:
+
+    div(alpha) = 2 * kappa
+    grad(psi)  = alpha
+    lap(psi)   = 2 * kappa
+
+using numerical differentiation independent of the source code.
+
+ExternalShear has physically zero convergence (pure shear field).
+MassSheet has zero potential_2d_from in the source code (placeholder).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import autogalaxy as ag
+from mass.util import make_grid, run_all_checks, print_summary_table, get_tolerances
+
+"""
+__Setup__
+"""
+
+grid = make_grid()
+tol = get_tolerances()
+results = []
+
+"""
+__External Shear__
+
+A pure external shear field has zero convergence by definition — it only
+contributes deflection angles proportional to the shear components.
+The convergence SKIP is physically correct.
+"""
+
+mp = ag.mp.ExternalShear(gamma_1=0.05, gamma_2=0.03)
+results.append(run_all_checks("ExternalShear", mp, grid, tol))
+
+"""
+__Mass Sheet__
+
+A uniform convergence sheet with kappa_ext. The potential is
+psi = 0.5 * kappa_ext * r^2, but potential_2d_from currently returns zeros.
+"""
+
+mp = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=0.1)
+results.append(run_all_checks("MassSheet", mp, grid, tol))
+
+"""
+__External Potential__
+
+Higher-order external potential with spin-1, spin-2, and spin-3 terms.
+"""
+
+mp = ag.mp.ExternalPotential(
+    centre=(0.0, 0.0),
+    gamma_1=0.04,
+    gamma_2=0.02,
+    tau_1=0.01,
+    tau_2=0.01,
+    delta_1=0.002,
+    delta_2=0.002,
+)
+results.append(run_all_checks("ExternalPotential", mp, grid, tol))
+
+"""
+__Summary__
+"""
+
+print("=" * 70)
+print("Sheet / Perturbation Profiles — Self-Consistency Results")
+print("=" * 70)
+print_summary_table(results)

--- a/scripts/mass/stellar.py
+++ b/scripts/mass/stellar.py
@@ -1,0 +1,219 @@
+"""
+Mass Profile Self-Consistency: Stellar Profiles
+================================================
+
+Verifies that stellar mass profiles (Sersic, Gaussian, Chameleon families)
+satisfy the fundamental lensing relations:
+
+    div(alpha) = 2 * kappa
+    grad(psi)  = alpha
+    lap(psi)   = 2 * kappa
+
+using numerical differentiation independent of the source code.
+
+Stellar profiles use ``mass_to_light_ratio`` and ``intensity`` instead of
+``einstein_radius``.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import autogalaxy as ag
+from mass.util import make_grid, run_all_checks, print_summary_table, get_tolerances
+
+"""
+__Setup__
+"""
+
+grid = make_grid()
+tol = get_tolerances()
+results = []
+
+"""
+__Sersic Family__
+
+AbstractSersic.potential_2d_from returns zeros.
+"""
+
+mp = ag.mp.Sersic(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.15,
+    effective_radius=0.8,
+    sersic_index=1.0,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("Sersic", mp, grid, tol))
+
+mp = ag.mp.SersicSph(
+    centre=(0.0, 0.0),
+    intensity=0.15,
+    effective_radius=0.8,
+    sersic_index=1.0,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("SersicSph", mp, grid, tol))
+
+"""
+__Sersic Core__
+"""
+
+mp = ag.mp.SersicCore(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    effective_radius=0.8,
+    sersic_index=1.0,
+    radius_break=0.01,
+    intensity=0.05,
+    gamma=0.25,
+    alpha=3.0,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("SersicCore", mp, grid, tol))
+
+mp = ag.mp.SersicCoreSph(
+    centre=(0.0, 0.0),
+    effective_radius=0.8,
+    sersic_index=1.0,
+    radius_break=0.01,
+    intensity=0.05,
+    gamma=0.25,
+    alpha=3.0,
+)
+results.append(run_all_checks("SersicCoreSph", mp, grid, tol))
+
+"""
+__Sersic Gradient__
+"""
+
+mp = ag.mp.SersicGradient(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.15,
+    effective_radius=0.8,
+    sersic_index=1.0,
+    mass_to_light_ratio=1.2,
+    mass_to_light_gradient=-0.3,
+)
+results.append(run_all_checks("SersicGradient", mp, grid, tol))
+
+mp = ag.mp.SersicGradientSph(
+    centre=(0.0, 0.0),
+    intensity=0.15,
+    effective_radius=0.8,
+    sersic_index=1.0,
+    mass_to_light_ratio=1.2,
+    mass_to_light_gradient=-0.3,
+)
+results.append(run_all_checks("SersicGradientSph", mp, grid, tol))
+
+"""
+__Gaussian Family__
+
+Gaussian.potential_2d_from returns zeros.
+"""
+
+mp = ag.mp.Gaussian(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.12,
+    sigma=0.9,
+    mass_to_light_ratio=1.1,
+)
+results.append(run_all_checks("Gaussian", mp, grid, tol))
+
+"""
+__Gaussian Gradient__
+"""
+
+mp = ag.mp.GaussianGradient(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.12,
+    sigma=0.9,
+    mass_to_light_ratio_base=1.1,
+    mass_to_light_gradient=-0.3,
+)
+results.append(run_all_checks("GaussianGradient", mp, grid, tol))
+
+"""
+__Exponential Family__
+
+Exponential is Sersic with sersic_index=1.0.
+"""
+
+mp = ag.mp.Exponential(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.15,
+    effective_radius=0.8,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("Exponential", mp, grid, tol))
+
+mp = ag.mp.ExponentialSph(
+    centre=(0.0, 0.0),
+    intensity=0.15,
+    effective_radius=0.8,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("ExponentialSph", mp, grid, tol))
+
+"""
+__DevVaucouleurs Family__
+
+DevVaucouleurs is Sersic with sersic_index=4.0.
+"""
+
+mp = ag.mp.DevVaucouleurs(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.15,
+    effective_radius=0.8,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("DevVaucouleurs", mp, grid, tol))
+
+mp = ag.mp.DevVaucouleursSph(
+    centre=(0.0, 0.0),
+    intensity=0.15,
+    effective_radius=0.8,
+    mass_to_light_ratio=1.2,
+)
+results.append(run_all_checks("DevVaucouleursSph", mp, grid, tol))
+
+"""
+__Chameleon Family__
+
+Chameleon.potential_2d_from returns zeros.
+"""
+
+mp = ag.mp.Chameleon(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    intensity=0.12,
+    core_radius_0=0.015,
+    core_radius_1=0.025,
+    mass_to_light_ratio=1.1,
+)
+results.append(run_all_checks("Chameleon", mp, grid, tol))
+
+mp = ag.mp.ChameleonSph(
+    centre=(0.0, 0.0),
+    intensity=0.12,
+    core_radius_0=0.015,
+    core_radius_1=0.025,
+    mass_to_light_ratio=1.1,
+)
+results.append(run_all_checks("ChameleonSph", mp, grid, tol))
+
+"""
+__Summary__
+"""
+
+print("=" * 70)
+print("Stellar Mass Profiles — Self-Consistency Results")
+print("=" * 70)
+print_summary_table(results)

--- a/scripts/mass/total.py
+++ b/scripts/mass/total.py
@@ -1,0 +1,173 @@
+"""
+Mass Profile Self-Consistency: Total Profiles
+==============================================
+
+Verifies that total mass profiles (Isothermal, PowerLaw, dPIE families)
+satisfy the fundamental lensing relations:
+
+    div(alpha) = 2 * kappa
+    grad(psi)  = alpha
+    lap(psi)   = 2 * kappa
+
+using numerical differentiation independent of the source code.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import autogalaxy as ag
+from mass.util import make_grid, run_all_checks, print_summary_table, get_tolerances
+
+"""
+__Setup__
+"""
+
+grid = make_grid()
+tol = get_tolerances()
+results = []
+
+"""
+__Isothermal Family__
+"""
+
+mp = ag.mp.Isothermal(
+    centre=(0.0, 0.0), ell_comps=(0.1, 0.05), einstein_radius=1.2
+)
+results.append(run_all_checks("Isothermal", mp, grid, tol))
+
+mp = ag.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=1.2)
+results.append(run_all_checks("IsothermalSph", mp, grid, tol))
+
+mp = ag.mp.IsothermalCore(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    einstein_radius=1.2,
+    core_radius=0.1,
+)
+results.append(run_all_checks("IsothermalCore", mp, grid, tol))
+
+mp = ag.mp.IsothermalCoreSph(
+    centre=(0.0, 0.0), einstein_radius=1.2, core_radius=0.1
+)
+results.append(run_all_checks("IsothermalCoreSph", mp, grid, tol))
+
+"""
+__Power Law Family__
+"""
+
+mp = ag.mp.PowerLaw(
+    centre=(0.0, 0.0),
+    ell_comps=(0.08, 0.04),
+    einstein_radius=1.1,
+    slope=2.1,
+)
+results.append(run_all_checks("PowerLaw", mp, grid, tol))
+
+mp = ag.mp.PowerLawSph(centre=(0.0, 0.0), einstein_radius=1.1, slope=2.1)
+results.append(run_all_checks("PowerLawSph", mp, grid, tol))
+
+mp = ag.mp.PowerLawCore(
+    centre=(0.0, 0.0),
+    ell_comps=(0.08, 0.04),
+    einstein_radius=1.1,
+    slope=2.1,
+    core_radius=0.1,
+)
+results.append(run_all_checks("PowerLawCore", mp, grid, tol))
+
+mp = ag.mp.PowerLawCoreSph(
+    centre=(0.0, 0.0), einstein_radius=1.1, slope=2.1, core_radius=0.1
+)
+results.append(run_all_checks("PowerLawCoreSph", mp, grid, tol))
+
+"""
+__Power Law Broken__
+
+potential_2d_from returns zeros — grad(psi) and lap(psi) checks will SKIP.
+"""
+
+mp = ag.mp.PowerLawBroken(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    einstein_radius=1.0,
+    inner_slope=1.3,
+    outer_slope=2.7,
+    break_radius=0.05,
+)
+results.append(run_all_checks("PowerLawBroken", mp, grid, tol))
+
+mp = ag.mp.PowerLawBrokenSph(
+    centre=(0.0, 0.0),
+    einstein_radius=1.0,
+    inner_slope=1.3,
+    outer_slope=2.7,
+    break_radius=0.05,
+)
+results.append(run_all_checks("PowerLawBrokenSph", mp, grid, tol))
+
+"""
+__Power Law Multipole__
+
+convergence_2d_from returns zeros (physically correct for a pure multipole
+perturbation). div(alpha) and lap(psi) checks will SKIP.
+"""
+
+mp = ag.mp.PowerLawMultipole(
+    centre=(0.0, 0.0),
+    einstein_radius=1.0,
+    slope=2.0,
+    m=4,
+    multipole_comps=(0.01, 0.01),
+)
+results.append(run_all_checks("PowerLawMultipole", mp, grid, tol))
+
+"""
+__dPIE Family__
+
+dPIEMass and dPIEPotential both return zeros for potential_2d_from.
+"""
+
+mp = ag.mp.dPIEMass(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    ra=0.02,
+    rs=2.5,
+    b0=0.15,
+)
+results.append(run_all_checks("dPIEMass", mp, grid, tol))
+
+mp = ag.mp.dPIEMassSph(
+    centre=(0.0, 0.0),
+    ra=0.02,
+    rs=2.5,
+    b0=0.15,
+)
+results.append(run_all_checks("dPIEMassSph", mp, grid, tol))
+
+mp = ag.mp.dPIEPotential(
+    centre=(0.0, 0.0),
+    ell_comps=(0.1, 0.05),
+    ra=0.02,
+    rs=2.5,
+    b0=0.15,
+)
+results.append(run_all_checks("dPIEPotential", mp, grid, tol))
+
+mp = ag.mp.dPIEPotentialSph(
+    centre=(0.0, 0.0),
+    ra=0.02,
+    rs=2.5,
+    b0=0.15,
+)
+results.append(run_all_checks("dPIEPotentialSph", mp, grid, tol))
+
+"""
+__Summary__
+"""
+
+print("=" * 70)
+print("Total Mass Profiles — Self-Consistency Results")
+print("=" * 70)
+print_summary_table(results)

--- a/scripts/mass/util.py
+++ b/scripts/mass/util.py
@@ -1,0 +1,260 @@
+"""
+Mass Profile Self-Consistency Utilities
+=======================================
+
+Shared numerical differentiation helpers and lensing relation checks used by
+all per-category mass profile test scripts.
+
+Set ``PYAUTO_MASS_FAST=1`` for smaller grids and looser tolerances.
+"""
+
+import os
+import numpy as np
+import autogalaxy as ag
+
+FAST = os.environ.get("PYAUTO_MASS_FAST", "0") == "1"
+
+
+def make_grid():
+    shape = (40, 40) if FAST else (100, 100)
+    return ag.Grid2D.uniform(shape_native=shape, pixel_scales=0.05)
+
+
+def get_tolerances():
+    return dict(rtol=5e-2) if FAST else dict(rtol=1e-2)
+
+
+def trim_border(arr, n=3):
+    return arr[n:-n, n:-n]
+
+
+def _to_native_2d(result, grid):
+    if hasattr(result, "native"):
+        return result.native
+    arr = np.asarray(result)
+    if arr.ndim == 1:
+        return arr.reshape(grid.shape_native)
+    return arr
+
+
+def _to_native_vector(result, grid):
+    if hasattr(result, "native"):
+        return result.native[:, :, 0], result.native[:, :, 1]
+    arr = np.asarray(result)
+    if arr.ndim == 2 and arr.shape[1] == 2:
+        vy = arr[:, 0].reshape(grid.shape_native)
+        vx = arr[:, 1].reshape(grid.shape_native)
+        return vy, vx
+    return arr[:, :, 0], arr[:, :, 1]
+
+
+def divergence_2d(vy, vx, dx):
+    # y decreases along axis 0 in autoarray native grids → negative spacing
+    dvy_dy = np.gradient(vy, -dx, axis=0)
+    dvx_dx = np.gradient(vx, dx, axis=1)
+    return dvy_dy + dvx_dx
+
+
+def gradient_2d(scalar, dx):
+    dscalar_dy = np.gradient(scalar, -dx, axis=0)
+    dscalar_dx = np.gradient(scalar, dx, axis=1)
+    return dscalar_dy, dscalar_dx
+
+
+def laplacian_2d(scalar, dx):
+    d2_dy2 = np.gradient(np.gradient(scalar, -dx, axis=0), -dx, axis=0)
+    d2_dx2 = np.gradient(np.gradient(scalar, dx, axis=1), dx, axis=1)
+    return d2_dy2 + d2_dx2
+
+
+def _is_zero(arr):
+    return np.allclose(arr, 0.0, atol=1e-14)
+
+
+def _both_near_zero(computed, expected, atol=1e-8):
+    return np.all(np.abs(computed) < atol) and np.all(np.abs(expected) < atol)
+
+
+def _max_rel_error(computed, expected):
+    scale = max(np.max(np.abs(expected)), 1e-10)
+    return float(np.max(np.abs(computed - expected)) / scale)
+
+
+def _median_rel_error(computed, expected):
+    scale = max(np.max(np.abs(expected)), 1e-10)
+    return float(np.median(np.abs(computed - expected)) / scale)
+
+
+def check_div_alpha_eq_2kappa(profile, grid, tol):
+    dx = grid.pixel_scales[0]
+
+    alpha = profile.deflections_yx_2d_from(grid=grid)
+    alpha_y, alpha_x = _to_native_vector(alpha, grid)
+
+    try:
+        kappa = profile.convergence_2d_from(grid=grid)
+    except NotImplementedError:
+        return "SKIP", "convergence not implemented"
+
+    kappa_2d = _to_native_2d(kappa, grid)
+
+    if _is_zero(kappa_2d):
+        return "SKIP", "convergence is zero"
+
+    div_alpha = divergence_2d(alpha_y, alpha_x, dx)
+
+    div_t = trim_border(div_alpha)
+    kappa_t = trim_border(kappa_2d)
+
+    if _is_zero(kappa_t):
+        return "SKIP", "convergence is zero (interior)"
+
+    if _both_near_zero(div_t, 2.0 * kappa_t):
+        return "PASS", "both ~0"
+
+    err = _max_rel_error(div_t, 2.0 * kappa_t)
+    med = _median_rel_error(div_t, 2.0 * kappa_t)
+
+    if med <= tol["rtol"]:
+        return "PASS", f"med={med:.1e} max={err:.1e}"
+    else:
+        return "FAIL", f"med={med:.1e} max={err:.1e}"
+
+
+def check_grad_psi_eq_alpha(profile, grid, tol):
+    dx = grid.pixel_scales[0]
+
+    try:
+        psi = profile.potential_2d_from(grid=grid)
+    except NotImplementedError:
+        return "SKIP", "potential not implemented"
+
+    psi_2d = _to_native_2d(psi, grid)
+
+    if _is_zero(psi_2d):
+        return "SKIP", "potential is zero"
+
+    alpha = profile.deflections_yx_2d_from(grid=grid)
+    alpha_y, alpha_x = _to_native_vector(alpha, grid)
+
+    grad_y, grad_x = gradient_2d(psi_2d, dx)
+
+    grad_y_t = trim_border(grad_y)
+    grad_x_t = trim_border(grad_x)
+    alpha_y_t = trim_border(alpha_y)
+    alpha_x_t = trim_border(alpha_x)
+
+    if _both_near_zero(grad_y_t, alpha_y_t) and _both_near_zero(grad_x_t, alpha_x_t):
+        return "PASS", "both ~0"
+
+    err_y = _max_rel_error(grad_y_t, alpha_y_t)
+    err_x = _max_rel_error(grad_x_t, alpha_x_t)
+    med_y = _median_rel_error(grad_y_t, alpha_y_t)
+    med_x = _median_rel_error(grad_x_t, alpha_x_t)
+
+    med = max(med_y, med_x)
+    err = max(err_y, err_x)
+
+    if med <= tol["rtol"]:
+        return "PASS", f"med={med:.1e} max={err:.1e}"
+    else:
+        return "FAIL", f"med={med:.1e} max={err:.1e}"
+
+
+def check_laplacian_psi_eq_2kappa(profile, grid, tol):
+    dx = grid.pixel_scales[0]
+
+    try:
+        psi = profile.potential_2d_from(grid=grid)
+    except NotImplementedError:
+        return "SKIP", "potential not implemented"
+
+    psi_2d = _to_native_2d(psi, grid)
+
+    if _is_zero(psi_2d):
+        return "SKIP", "potential is zero"
+
+    try:
+        kappa = profile.convergence_2d_from(grid=grid)
+    except NotImplementedError:
+        return "SKIP", "convergence not implemented"
+
+    kappa_2d = _to_native_2d(kappa, grid)
+
+    if _is_zero(kappa_2d):
+        return "SKIP", "convergence is zero"
+
+    lap = laplacian_2d(psi_2d, dx)
+
+    lap_t = trim_border(lap)
+    kappa_t = trim_border(kappa_2d)
+
+    if _both_near_zero(lap_t, 2.0 * kappa_t):
+        return "PASS", "both ~0"
+
+    err = _max_rel_error(lap_t, 2.0 * kappa_t)
+    med = _median_rel_error(lap_t, 2.0 * kappa_t)
+
+    if med <= tol["rtol"]:
+        return "PASS", f"med={med:.1e} max={err:.1e}"
+    else:
+        return "FAIL", f"med={med:.1e} max={err:.1e}"
+
+
+def run_all_checks(name, profile, grid, tol):
+    r1_status, r1_detail = check_div_alpha_eq_2kappa(profile, grid, tol)
+    r2_status, r2_detail = check_grad_psi_eq_alpha(profile, grid, tol)
+    r3_status, r3_detail = check_laplacian_psi_eq_2kappa(profile, grid, tol)
+
+    return {
+        "name": name,
+        "div_alpha": (r1_status, r1_detail),
+        "grad_psi": (r2_status, r2_detail),
+        "lap_psi": (r3_status, r3_detail),
+    }
+
+
+def print_summary_table(results_list):
+    hdr = f"| {'Profile':<28} | {'div(a)=2k':<16} | {'grad(p)=a':<16} | {'lap(p)=2k':<16} |"
+    sep = f"|{'-'*30}|{'-'*18}|{'-'*18}|{'-'*18}|"
+    print()
+    print(hdr)
+    print(sep)
+
+    n_pass = 0
+    n_fail = 0
+    n_skip = 0
+
+    for r in results_list:
+        cols = []
+        for key in ("div_alpha", "grad_psi", "lap_psi"):
+            status, detail = r[key]
+            if status == "PASS":
+                cols.append(f"PASS {detail.split(' ')[0]}")
+                n_pass += 1
+            elif status == "SKIP":
+                cols.append(f"SKIP")
+                n_skip += 1
+            else:
+                cols.append(f"FAIL {detail.split(' ')[0]}")
+                n_fail += 1
+
+        print(f"| {r['name']:<28} | {cols[0]:<16} | {cols[1]:<16} | {cols[2]:<16} |")
+
+    print()
+    print(f"Summary: {n_pass} PASS / {n_fail} FAIL / {n_skip} SKIP")
+
+    if n_fail > 0:
+        print()
+        print("FAILURES:")
+        for r in results_list:
+            for key, label in [
+                ("div_alpha", "div(a)=2k"),
+                ("grad_psi", "grad(p)=a"),
+                ("lap_psi", "lap(p)=2k"),
+            ]:
+                status, detail = r[key]
+                if status == "FAIL":
+                    print(f"  {r['name']} — {label}: {detail}")
+
+    print()


### PR DESCRIPTION
## Summary

New `scripts/mass/` directory with per-category self-consistency tests for every mass profile in PyAutoGalaxy. Each script verifies lensing relations (div(α)=2κ, ∇ψ=α, ∇²ψ=2κ) via numerical differentiation independent of the source code. Phase 1 of the mass profiles refactoring epic (PyAutoGalaxy#445).

Results across all 5 scripts: **56 PASS / 1 FAIL / 69 SKIP**. The single FAIL is NFWSph `grad(ψ)=α` at 11% median error — a genuine potential-deflection mismatch worth investigating. All SKIPs are expected (zero-returning methods or not-implemented potentials).

## Scripts Changed

- `scripts/mass/__init__.py` — package marker
- `scripts/mass/util.py` — shared numerical differentiation utilities, lensing relation checks, summary table printer
- `scripts/mass/total.py` — Isothermal, PowerLaw, dPIE families (15 profiles, 31 PASS / 14 SKIP)
- `scripts/mass/dark.py` — NFW, gNFW, cNFW families (7 profiles, 6 PASS / 1 FAIL / 14 SKIP)
- `scripts/mass/stellar.py` — Sersic, Gaussian, Chameleon families (14 profiles, 14 PASS / 28 SKIP)
- `scripts/mass/sheets.py` — ExternalShear, MassSheet, ExternalPotential (3 profiles, 5 PASS / 4 SKIP)
- `scripts/mass/point.py` — PointMass, SMBH, SMBHBinary (3 profiles, 0 PASS / 9 SKIP)

## Test Plan

- [x] `python scripts/mass/total.py` — 31 PASS / 0 FAIL / 14 SKIP
- [x] `python scripts/mass/dark.py` — 6 PASS / 1 FAIL / 14 SKIP
- [x] `python scripts/mass/stellar.py` — 14 PASS / 0 FAIL / 28 SKIP
- [x] `python scripts/mass/sheets.py` — 5 PASS / 0 FAIL / 4 SKIP
- [x] `python scripts/mass/point.py` — 0 PASS / 0 FAIL / 9 SKIP
- [x] `PYAUTO_MASS_FAST=1` mode supported

🤖 Generated with [Claude Code](https://claude.com/claude-code)