### PR TITLE
fix(smoke): extend latent_variables smoke to new 8-key registry

### DIFF
--- a/config/latent.yaml
+++ b/config/latent.yaml
@@ -1,9 +1,17 @@
 # Workspace overrides for the library lensing latent toggles. Enables
-# all five default latents so the smoke test exercises every entry in
-# `autolens.analysis.latent.LATENT_FUNCTIONS`. See
+# every entry in `autolens.analysis.latent.LATENT_FUNCTIONS` so the smoke
+# test exercises the full registry. See
 # `scripts/latent/latent_variables_smoke.py`.
+total_lens_flux: true
+total_lensed_source_flux: true
+total_source_flux: true
 total_lens_flux_mujy: true
 total_lensed_source_flux_mujy: true
 total_source_flux_mujy: true
 magnification: true
 effective_einstein_radius: true
+
+# autogalaxy library default (loaded by autoconf into the same `latent`
+# conf node) — explicitly disabled here to silence the cross-library
+# "unknown latent" warning that would otherwise fire on every fit.
+total_galaxy_0_flux: false

--- a/scripts/latent/latent_variables_smoke.py
+++ b/scripts/latent/latent_variables_smoke.py
@@ -7,7 +7,10 @@ materialises the latent samples via ``analysis.compute_latent_samples``,
 and asserts every default-enabled key in ``autolens.analysis.latent.LATENT_FUNCTIONS``
 is present with a finite value in a loose order-of-magnitude bracket.
 
-The workspace ``config/latent.yaml`` enables all five library latents.
+The workspace ``config/latent.yaml`` enables every entry in
+``LATENT_FUNCTIONS`` — three raw-flux latents (instrument-input-free),
+three µJy variants (require ``magzero``, which the smoke fixture
+supplies), plus ``magnification`` and ``effective_einstein_radius``.
 The brackets are deliberately loose so PYAUTO_SMALL_DATASETS grid mutations
 (15x15) still yield passing values; the goal is a structural regression
 guard, not Bayesian validation.
@@ -43,6 +46,9 @@ search = af.Nautilus(
 result = search.fit(model=model, analysis=analysis)
 
 EXPECTED_KEYS = [
+    "total_lens_flux",
+    "total_lensed_source_flux",
+    "total_source_flux",
     "total_lens_flux_mujy",
     "total_lensed_source_flux_mujy",
     "total_source_flux_mujy",


### PR DESCRIPTION
## Summary

PyAutoLabs/PyAutoLens#557 grows `LATENT_FUNCTIONS` from 5 keys to 8 by adding three raw-flux latents. The existing `latent_variables_smoke.py` asserts that `EXPECTED_KEYS` exactly matches `LATENT_FUNCTIONS.keys()`, so without this update the smoke would fail on a clean fit. This PR extends the smoke to cover all 8 keys and silences a cross-library "unknown latent" warning in the workspace config.

## Scripts Changed

- `config/latent.yaml` — Add the three new raw-flux keys explicitly (`total_lens_flux`, `total_lensed_source_flux`, `total_source_flux`, all `true`). Add `total_galaxy_0_flux: false` to silence the autogalaxy library default that autoconf merges into autolens's conf node.
- `scripts/latent/latent_variables_smoke.py` — `EXPECTED_KEYS` extended from 5 to 8 entries. Docstring updated to describe the new "raw / µJy / dimensionless" registry grouping. No other changes — the assertion logic and finite-value checks already cover the new keys.

## Upstream PR

- PyAutoLabs/PyAutoLens#557 — library change that grows the registry (must merge first per library-first gate)
- PyAutoLabs/PyAutoGalaxy#463 — sibling library change

## Test Plan

- [x] `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_DISABLE_JAX=1 PYAUTO_FAST_PLOTS=1 python scripts/latent/latent_variables_smoke.py` — passes 8/8 latents finite, zero "unknown latent" warnings.

Refs PyAutoLabs/PyAutoLens#556

🤖 Generated with [Claude Code](https://claude.com/claude-code)