### PR TITLE
ci(smoke): force-reinstall local PyAutoConf at end of install step

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -72,6 +72,12 @@ jobs:
         pip install "jax<0.7" "jaxlib<0.7"
         pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"
         pip install tensorflow-probability==0.25.0
+        # The [optional] re-resolution above can upgrade autoconf to the
+        # stale PyPI release (setuptools_scm reports the local copy as
+        # 1.0.dev0 from the shallow checkout). Pin the local source one
+        # last time so site-packages has skip_latents() and other recent
+        # autoconf APIs available at import time.
+        pip install --force-reinstall --no-deps ./PyAutoConf
     - name: Prepare cache dirs
       run: |
         mkdir -p /tmp/numba_cache /tmp/matplotlib


### PR DESCRIPTION
## Summary

`database/scrape/general.py` smoke CI failed with `ImportError: cannot import name 'skip_latents' from 'autoconf.test_mode'`. Even though `autoconf` main has had `skip_latents()` since PyAutoConf #109 (2026-05-21), the smoke CI was running an older PyPI autoconf.

Root cause: setuptools_scm derives PyAutoConf's local version as `1.0.dev0` from the shallow CI checkout, and the subsequent `pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]" "./PyAutoLens[optional]"` line re-resolves dependencies and upgrades `autoconf` to the PyPI release (`2026.5.14.1`, which predates `skip_latents`).

Append `pip install --force-reinstall --no-deps ./PyAutoConf` to the install block so the final autoconf in site-packages is from the local main checkout, regardless of intermediate `[optional]` resolutions. Mirroring on `autogalaxy_workspace_test` to keep the two workspace_test repos in sync.

## Test plan

- [ ] Smoke Tests advance past the `ImportError: skip_latents` line.
- [ ] `database/scrape/general.py` either passes, or surfaces its pre-existing `linear_light_profile_intensity_dict.__hash__` NEEDS_FIX bug from 2026-04-27 (a separate issue to address downstream).
- [ ] Other smoke scripts continue uninterrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)