### PR TITLE
ci(env): unset PYAUTO_SMALL_DATASETS for jax_substructure/ scripts

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -24,6 +24,13 @@ overrides:
   # JAX likelihood functions test JIT compilation — need JAX enabled and full-size datasets
   - pattern: "jax_likelihood_functions/"
     unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+  # JAX substructure scripts test the full simulate_substructure / batched_simulate_substructure
+  # path with an explicit image_shape=(51,51). PYAUTO_SMALL_DATASETS=1 clamps the input grid
+  # to 15x15 (225 points) but image_shape is left alone, so the reshape inside
+  # simulate_substructure (substructure_util.py:168) raises a 225 vs 2601 TypeError.
+  # Same JAX-with-full-dataset pattern as jax_likelihood_functions/.
+  - pattern: "jax_substructure/"
+    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
   # Database scrape scripts need real search output on disk — no test env vars
   - pattern: "database/scrape/"
     unset:


### PR DESCRIPTION
## Summary

`simulate_substructure` (PyAutoLens `substructure_util.py:168`) reshapes `image_1d` to the caller's explicit `image_shape`. The `jax_substructure/` test scripts pass `image_shape=(51,51)`, but `PYAUTO_SMALL_DATASETS=1` clamps `Grid2D.uniform` to `15x15` internally, so the reshape sees 225 elements against 2601 and raises `TypeError: cannot reshape array of shape (225,) (size 225) into shape (51, 51) (size 2601)`.

The new `jax_substructure/` directory shipped in PRs #127/#128/#129 (2026-05-26) without the matching env override that `jax_likelihood_functions/` has had since its inception.

Mirror the existing `jax_likelihood_functions/` override: unset `PYAUTO_SMALL_DATASETS` and `PYAUTO_DISABLE_JAX` for the `jax_substructure/` directory.

## Test plan

- [x] `PYAUTO_SMALL_DATASETS=1 python scripts/jax_substructure/test_simulate_e2e.py` reproduces the `225 vs 2601` TypeError.
- [x] Same script **without** `PYAUTO_SMALL_DATASETS` set + `JAX_ENABLE_X64=True` prints all 3 PASS asserts and exits 0.
- [ ] Next `autobuild run_all autolens_test` run flips `jax_substructure/{test_simulate_e2e,test_batched_simulate}.py` from FAIL to PASS.

## Follow-up

`autolens_workspace/scripts/imaging/features/advanced/los_halos/{simulator,simulator_jax}.py` TIMEOUTs at 300s — separate root cause (real-time wall clock, not env-var mismatch). Tracked for a later prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)