### PR TITLE
test(mass): convergence_func enclosed-mass cross-check

### DIFF
--- a/scripts/mass/dark.py
+++ b/scripts/mass/dark.py
@@ -27,6 +27,8 @@ from mass.util import (
     run_all_checks,
     run_param_sweep,
     print_summary_table,
+    check_convergence_func_enclosed_mass,
+    print_convergence_func_table,
     get_tolerances,
     MODE,
 )
@@ -195,3 +197,29 @@ print("=" * 70)
 print(f"Dark Matter Profiles — Self-Consistency Results (mode={MODE})")
 print("=" * 70)
 print_summary_table(results)
+
+"""
+__convergence_func Enclosed Mass__
+
+Directly exercises `convergence_func` via radial mass integration (the Einstein-radius
+path) — the only path that reaches cNFW's `convergence_func`, since its `convergence_2d_from`
+goes through MGE-of-3D-density and never calls it. NFWSph is an analytic positive control;
+cNFWSph is the profile whose `convergence_func` was newly added.
+"""
+
+cf_results = [
+    check_convergence_func_enclosed_mass(
+        "NFWSph",
+        ag.mp.NFWSph(centre=(0.0, 0.0), kappa_s=0.2, scale_radius=1.2),
+        tol,
+    ),
+    check_convergence_func_enclosed_mass(
+        "cNFWSph",
+        ag.mp.cNFWSph(
+            centre=(0.0, 0.0), kappa_s=0.2, scale_radius=1.2, core_radius=0.15
+        ),
+        tol,
+    ),
+]
+
+print_convergence_func_table(cf_results)

--- a/scripts/mass/total.py
+++ b/scripts/mass/total.py
@@ -23,6 +23,8 @@ from mass.util import (
     run_all_checks,
     run_param_sweep,
     print_summary_table,
+    check_convergence_func_enclosed_mass,
+    print_convergence_func_table,
     get_tolerances,
     MODE,
 )
@@ -303,3 +305,45 @@ print("=" * 70)
 print(f"Total Mass Profiles — Self-Consistency Results (mode={MODE})")
 print("=" * 70)
 print_summary_table(results)
+
+"""
+__convergence_func Enclosed Mass__
+
+Directly exercises `convergence_func` via radial mass integration (the Einstein-radius
+path). PowerLawSph is an analytic positive control; PowerLawBrokenSph is the profile whose
+`convergence_func` was newly added (reached today via its MGE potential too). PowerLawMultipole
+encloses zero net mass (zero monopole).
+"""
+
+cf_results = [
+    check_convergence_func_enclosed_mass(
+        "PowerLawSph",
+        ag.mp.PowerLawSph(centre=(0.0, 0.0), einstein_radius=1.1, slope=2.1),
+        tol,
+    ),
+    check_convergence_func_enclosed_mass(
+        "PowerLawBrokenSph",
+        ag.mp.PowerLawBrokenSph(
+            centre=(0.0, 0.0),
+            einstein_radius=1.0,
+            inner_slope=1.3,
+            outer_slope=2.7,
+            break_radius=0.05,
+        ),
+        tol,
+    ),
+    check_convergence_func_enclosed_mass(
+        "PowerLawMultipole",
+        ag.mp.PowerLawMultipole(
+            centre=(0.0, 0.0),
+            einstein_radius=1.0,
+            slope=2.0,
+            m=4,
+            multipole_comps=(0.01, 0.01),
+        ),
+        tol,
+        expect_zero=True,
+    ),
+]
+
+print_convergence_func_table(cf_results)

--- a/scripts/mass/util.py
+++ b/scripts/mass/util.py
@@ -233,6 +233,62 @@ def run_all_checks(name, profile, grid, tol):
     }
 
 
+def check_convergence_func_enclosed_mass(name, profile, tol, radius=1.0, expect_zero=False):
+    """Exercise `convergence_func` end-to-end via radial mass integration.
+
+    `mass_angular_within_circle_from(R)` integrates `2*pi*r*kappa(r)` (`mass_integral`),
+    which calls `convergence_func` through `scipy.integrate.quad`. This is the *only* path
+    that reaches `convergence_func` for profiles whose `convergence_2d_from` does not delegate
+    to it (PowerLawBroken via MGE potential, cNFW via MGE-of-3D-density, PowerLawMultipole).
+
+    For a spherical profile the enclosed 2D mass equals `pi * R * alpha_r(R)` from the
+    independent deflection field — a cross-check that needs no source-code internals. For a
+    pure multipole (`expect_zero=True`) the enclosed mass is zero (zero azimuthally-averaged
+    convergence)."""
+
+    try:
+        mass = float(profile.mass_angular_within_circle_from(radius=radius))
+    except Exception as e:  # surface NotImplementedError or any regression as a FAIL row
+        return {"name": name, "status": "FAIL", "detail": f"raised {type(e).__name__}"}
+
+    if expect_zero:
+        status = "PASS" if abs(mass) < 1e-6 else "FAIL"
+        return {"name": name, "status": status, "detail": f"mass={mass:.2e} (expect 0)"}
+
+    alpha = np.asarray(profile.deflections_yx_2d_from(grid=ag.Grid2DIrregular([[0.0, radius]])))
+    alpha_r = float(np.hypot(alpha[0, 0], alpha[0, 1]))
+    expected = np.pi * radius * alpha_r
+
+    if abs(expected) < 1e-10:
+        return {"name": name, "status": "SKIP", "detail": "deflection ~0"}
+
+    rel = abs(mass - expected) / abs(expected)
+    status = "PASS" if rel <= tol["rtol"] else "FAIL"
+    return {"name": name, "status": status, "detail": f"mass={mass:.4f} piRa={expected:.4f} rel={rel:.1e}"}
+
+
+def print_convergence_func_table(results_list):
+    print()
+    print("convergence_func enclosed-mass cross-check (mass_integral -> convergence_func):")
+    print(f"| {'Profile':<28} | {'enclosed mass = pi*R*alpha':<46} |")
+    print(f"|{'-'*30}|{'-'*48}|")
+
+    n_pass = n_fail = n_skip = 0
+    for r in results_list:
+        cell = f"{r['status']} {r['detail']}"
+        print(f"| {r['name']:<28} | {cell:<46} |")
+        if r["status"] == "PASS":
+            n_pass += 1
+        elif r["status"] == "FAIL":
+            n_fail += 1
+        else:
+            n_skip += 1
+
+    print()
+    print(f"convergence_func: {n_pass} PASS / {n_fail} FAIL / {n_skip} SKIP")
+    print()
+
+
 def print_summary_table(results_list):
     hdr = f"| {'Profile':<28} | {'div(a)=2k':<16} | {'grad(p)=a':<16} | {'lap(p)=2k':<16} |"
     sep = f"|{'-'*30}|{'-'*18}|{'-'*18}|{'-'*18}|"


### PR DESCRIPTION
## Summary

Adds an end-to-end cross-check that exercises the new `convergence_func` overrides (PyAutoGalaxy #467) via radial mass integration. `mass_angular_within_circle_from` routes through `mass_integral` → `convergence_func`; for a spherical profile the enclosed 2D mass must equal `π·R·α(R)` from the independent deflection field, and a pure multipole encloses zero net mass.

## Scripts Changed
- `scripts/mass/util.py` — added `check_convergence_func_enclosed_mass` (mass_angular = πR·α cross-check, or expect-zero for the multipole) and `print_convergence_func_table`.
- `scripts/mass/total.py` — added a convergence_func enclosed-mass section (PowerLawSph control, PowerLawBrokenSph, PowerLawMultipole).
- `scripts/mass/dark.py` — added a convergence_func enclosed-mass section (NFWSph control, cNFWSph).

## Upstream PR
https://github.com/PyAutoLabs/PyAutoGalaxy/pull/467

## Test Plan
- [x] `python scripts/mass/total.py` & `scripts/mass/dark.py` run clean; convergence_func cross-check PASS for all profiles (PowerLawBrokenSph rel 1.7e-11, cNFWSph rel 1.5e-4, PowerLawMultipole 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)