### PR TITLE
fix: create convolution image directory

### DIFF
--- a/scripts/imaging/convolution.py
+++ b/scripts/imaging/convolution.py
@@ -135,6 +135,7 @@ via_real_space = dataset.psf.convolved_image_via_real_space_np_from(
 residuals = via_fft.native - via_real_space.native
 
 script_path = Path("scripts") / "imaging" / "images"
+script_path.mkdir(parents=True, exist_ok=True)
 
 print(f"Max residual = {residuals.max()}")
 print(


### PR DESCRIPTION
## Summary
Create the convolution diagnostic image directory before saving `residuals.png`, making the script independent of developer-local artifacts.

## Scripts Changed
- `scripts/imaging/convolution.py` — create `scripts/imaging/images/` before saving the residual plot.

## Test Plan
- [x] Script passes from a missing `scripts/imaging/images/` directory
- [x] Integration workspace smoke tests: 15/15 passed

🤖 Generated with [Codex](https://openai.com/codex/)