### PR TITLE
fix: zero_contour warm-perf assertion uses cold/warm ratio

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -27,6 +27,7 @@
 - imaging/modeling_visualization_jit_delaunay # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap; same root cause as modeling_visualization_jit
 - imaging/modeling_visualization_jit_rectangular # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 301s cap; same root cause as modeling_visualization_jit
 - interferometer/modeling_visualization_jit # SLOW 2026-05-20 - JIT + full visualization pipeline exceeds 300s cap; same root cause as imaging/modeling_visualization_jit family
+- point_source/modeling_visualization_jit # SLOW 2026-07-08 - JIT + Part-2 live Nautilus fit exceeds 300s cap; same family as imaging/interferometer modeling_visualization_jit (the zero_contour perf-assert false-positive was separately fixed to a cold/warm ratio, which now lets the script run past it into the slow fit)
 - jax_likelihood_functions/imaging/delaunay_mge # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -157,7 +157,9 @@ _sanity_source = al.Galaxy(redshift=1.0)
 _sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
 _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
-_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_t0 = _sanity_time.perf_counter()
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # cold: first call on fresh instance (JIT compile)
+_sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
     "no tangential critical curves returned by zero_contour — algorithmic "
     "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
@@ -172,15 +174,25 @@ print(
     f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
 )
 
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
 _t0 = _sanity_time.perf_counter()
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm (cached solver)
 _warm_dt = _sanity_time.perf_counter() - _t0
-assert _warm_dt < 0.1, (
-    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
-    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+# Hardware-independent guard: the warm (cached) call must be much faster than
+# the cold JIT-compiling first call. A closure cache-busting regression
+# (PyAutoGalaxy #433) recompiles the solver every call, so warm ~= cold (ratio
+# near 1). An absolute millisecond budget instead false-positives on slower
+# machines where the honest warm call legitimately exceeds it. Mirrors the
+# compile-vs-cached ratio guard used elsewhere in this suite.
+assert _warm_dt < _sanity_cold_dt * 0.5, (
+    f"zero_contour warm call {_warm_dt * 1000:.1f} ms vs cold "
+    f"{_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f}) — "
+    "warm should be much faster than the cold compile; a ratio near 1 means the "
+    "closure cache-busting bug from PyAutoGalaxy #433 has regressed"
 )
-print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+print(
+    f"  PASS Visualization Sanity (perf): warm {_warm_dt * 1000:.1f} ms vs "
+    f"cold {_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f})"
+)
 
 # Interferometer-specific: model_data (complex Visibilities) finite + non-zero.
 _fit_for_vis = analysis.fit_from(instance=instance)

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -160,7 +160,9 @@ _sanity_source = al.Galaxy(redshift=1.0)
 _sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
 _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
-_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_t0 = _sanity_time.perf_counter()
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # cold: first call on fresh instance (JIT compile)
+_sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
     "no tangential critical curves returned by zero_contour — algorithmic "
     "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
@@ -175,15 +177,25 @@ print(
     f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
 )
 
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
 _t0 = _sanity_time.perf_counter()
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm (cached solver)
 _warm_dt = _sanity_time.perf_counter() - _t0
-assert _warm_dt < 0.1, (
-    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
-    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+# Hardware-independent guard: the warm (cached) call must be much faster than
+# the cold JIT-compiling first call. A closure cache-busting regression
+# (PyAutoGalaxy #433) recompiles the solver every call, so warm ~= cold (ratio
+# near 1). An absolute millisecond budget instead false-positives on slower
+# machines where the honest warm call legitimately exceeds it. Mirrors the
+# compile-vs-cached ratio guard used elsewhere in this suite.
+assert _warm_dt < _sanity_cold_dt * 0.5, (
+    f"zero_contour warm call {_warm_dt * 1000:.1f} ms vs cold "
+    f"{_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f}) — "
+    "warm should be much faster than the cold compile; a ratio near 1 means the "
+    "closure cache-busting bug from PyAutoGalaxy #433 has regressed"
 )
-print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+print(
+    f"  PASS Visualization Sanity (perf): warm {_warm_dt * 1000:.1f} ms vs "
+    f"cold {_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f})"
+)
 
 
 """

--- a/scripts/point_source/visualization_jax.py
+++ b/scripts/point_source/visualization_jax.py
@@ -151,7 +151,9 @@ _sanity_source = al.Galaxy(redshift=1.0)
 _sanity_tracer = al.Tracer(galaxies=[_sanity_lens, _sanity_source])
 _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
-_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_t0 = _sanity_time.perf_counter()
+_tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # cold: first call on fresh instance (JIT compile)
+_sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
     "no tangential critical curves returned by zero_contour — algorithmic "
     "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
@@ -166,12 +168,22 @@ print(
     f"{len(_tc_list)} tangential CC, einstein_radius={float(_er_sanity):.4f}"
 )
 
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm cache
 _t0 = _sanity_time.perf_counter()
-_sanity_od.tangential_critical_curve_list_via_zero_contour_from()
+_sanity_od.tangential_critical_curve_list_via_zero_contour_from()  # warm (cached solver)
 _warm_dt = _sanity_time.perf_counter() - _t0
-assert _warm_dt < 0.1, (
-    f"zero_contour warm call took {_warm_dt * 1000:.1f} ms (> 100 ms) — "
-    "closure cache-busting bug from PyAutoGalaxy #433 may have regressed"
+# Hardware-independent guard: the warm (cached) call must be much faster than
+# the cold JIT-compiling first call. A closure cache-busting regression
+# (PyAutoGalaxy #433) recompiles the solver every call, so warm ~= cold (ratio
+# near 1). An absolute millisecond budget instead false-positives on slower
+# machines where the honest warm call legitimately exceeds it. Mirrors the
+# compile-vs-cached ratio guard used elsewhere in this suite.
+assert _warm_dt < _sanity_cold_dt * 0.5, (
+    f"zero_contour warm call {_warm_dt * 1000:.1f} ms vs cold "
+    f"{_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f}) — "
+    "warm should be much faster than the cold compile; a ratio near 1 means the "
+    "closure cache-busting bug from PyAutoGalaxy #433 has regressed"
 )
-print(f"  PASS Visualization Sanity (perf): warm call {_warm_dt * 1000:.1f} ms")
+print(
+    f"  PASS Visualization Sanity (perf): warm {_warm_dt * 1000:.1f} ms vs "
+    f"cold {_sanity_cold_dt * 1000:.1f} ms (ratio {_warm_dt / _sanity_cold_dt:.2f})"
+)


### PR DESCRIPTION
Fixes #147.

Converts the `zero_contour` warm-perf guard in 3 JAX visualization scripts from an absolute `warm < 100 ms` budget to a hardware-independent `warm < cold * 0.5` ratio (the cache gives ~160× speedup; a real #433 cache-bust makes warm ≈ cold). Parks `point_source/modeling_visualization_jit` as SLOW (332 s, over the 300 s cap) alongside its imaging/interferometer siblings.

**Verified:** `point_source/visualization_jax` + `interferometer/visualization_jax` run to completion (exit 0), ratios 0.00–0.01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)