### PR TITLE
test: JAX finite-difference gradient correctness suite (jax_grad)

### DIFF
--- a/scripts/jax_grad/imaging_lp.py
+++ b/scripts/jax_grad/imaging_lp.py
@@ -1,7 +1,24 @@
 """
-Tests that jax.value_and_grad can compute finite, non-NaN gradients of the log-likelihood
-for an imaging model with parametric light profiles. This tests the core JAX differentiability
-that enables gradient-based inference.
+Tests JAX gradients of the imaging log-likelihood for parametric light-profile
+models, in two stages:
+
+ 1. Finiteness — ``jax.value_and_grad`` returns a finite log-likelihood and a
+    finite, non-zero gradient vector (the original check).
+ 2. Correctness — the autodiff gradient agrees with central finite differences
+    parameter-by-parameter (see ``util.py``).
+
+Two model variants are exercised so both light-profile evaluation paths are
+covered:
+
+ - ``lp.Sersic`` — standard profiles with free ``intensity`` (pure profile
+   evaluation, no inversion).
+ - ``lp_linear.Sersic`` — linear profiles whose intensities are solved by the
+   linear inversion (positive-only NNLS solve inside the likelihood).
+
+Autodiff runs on the eager (un-jitted) likelihood; the finite-difference
+evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
+consistency check at the base point so ``pure_callback`` constant-folding
+cannot fake the comparison.
 """
 
 import numpy as np
@@ -12,7 +29,9 @@ from os import path
 import autofit as af
 import autolens as al
 
-dataset_name = "simple"
+import util
+
+dataset_name = "jax_test"
 dataset_path = path.join("dataset", "imaging", dataset_name)
 
 """
@@ -21,7 +40,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 
@@ -34,7 +53,7 @@ dataset = al.Imaging.from_fits(
     data_path=path.join(dataset_path, "data.fits"),
     psf_path=path.join(dataset_path, "psf.fits"),
     noise_map_path=path.join(dataset_path, "noise_map.fits"),
-    pixel_scales=0.1,
+    pixel_scales=0.2,
 )
 
 mask_radius = 3.0
@@ -53,71 +72,133 @@ positions = al.Grid2DIrregular(
     al.from_json(file_path=path.join(dataset_path, "positions.json"))
 )
 
-# Lens:
 
-bulge = af.Model(al.lp_linear.Sersic)
+def model_from(bulge_cls):
+    """
+    The lens + source model used by both variants; only the bulge light-profile
+    class differs (standard vs linear Sersic).
+    """
+    lens = af.Model(
+        al.Galaxy,
+        redshift=0.5,
+        bulge=af.Model(bulge_cls),
+        mass=af.Model(al.mp.PowerLaw),
+        shear=af.Model(al.mp.ExternalShear),
+    )
+    source = af.Model(al.Galaxy, redshift=1.0, bulge=af.Model(bulge_cls))
+    return af.Collection(galaxies=af.Collection(lens=lens, source=source))
 
-mass = af.Model(al.mp.PowerLaw)
-
-shear = af.Model(al.mp.ExternalShear)
-
-lens = af.Model(
-    al.Galaxy,
-    redshift=0.5,
-    bulge=bulge,
-    mass=mass,
-    shear=shear,
-)
-
-# Source:
-
-bulge = af.Model(al.lp_linear.Sersic)
-
-source = af.Model(al.Galaxy, redshift=1.0, bulge=bulge)
-
-# Overall Lens Model:
-
-model = af.Collection(galaxies=af.Collection(lens=lens, source=source))
-
-print(model.info)
-
-analysis = al.AnalysisImaging(
-    dataset=dataset,
-    positions_likelihood_list=[al.PositionsLH(threshold=0.4, positions=positions)],
-)
 
 from autofit.non_linear.fitness import Fitness
 
-fitness = Fitness(
-    model=model,
-    analysis=analysis,
-    fom_is_log_likelihood=True,
-    resample_figure_of_merit=-1.0e99,
-)
+for variant, bulge_cls in [
+    ("lp.Sersic (standard)", al.lp.Sersic),
+    ("lp_linear.Sersic (linear)", al.lp_linear.Sersic),
+]:
+    print(f"\n=== {variant} ===")
 
-param_vector = jnp.array(model.physical_values_from_prior_medians)
+    model = model_from(bulge_cls=bulge_cls)
 
-# Perturb ell_comps away from (0,0) to avoid degenerate gradients at the
-# circular-profile singularity (arctan2 gradient is undefined at exactly (0,0)).
-key = jax.random.PRNGKey(0)
-perturbation = jax.random.uniform(
-    key, shape=param_vector.shape, minval=0.01, maxval=0.05
-)
-param_vector = param_vector + perturbation
+    analysis = al.AnalysisImaging(
+        dataset=dataset,
+        positions_likelihood_list=[al.PositionsLH(threshold=0.4, positions=positions)],
+    )
 
-value, grad = jax.value_and_grad(fitness.call)(param_vector)
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
 
-print(f"Log likelihood = {float(value):.6f}")
-print(f"Gradient shape = {grad.shape}")
-print(f"Gradient = {np.array(grad)}")
+    param_vector = jnp.array(model.physical_values_from_prior_medians)
 
-assert np.isfinite(float(value)), "Log likelihood is not finite"
-assert grad.shape == (
-    model.total_free_parameters,
-), f"Gradient shape mismatch: {grad.shape}"
-assert np.all(
-    np.isfinite(np.array(grad))
-), f"Gradient contains non-finite values: {np.array(grad)}"
-assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+    # Perturb ell_comps away from (0,0) to avoid degenerate gradients at the
+    # circular-profile singularity (arctan2 gradient is undefined at exactly (0,0)).
+    key = jax.random.PRNGKey(0)
+    perturbation = jax.random.uniform(
+        key, shape=param_vector.shape, minval=0.01, maxval=0.05
+    )
+    param_vector = param_vector + perturbation
 
-print("imaging_lp.py JAX gradient checks passed.")
+    # Anchor the mass model and source near the simulator truth (jax_test). At raw
+    # prior medians the fit is so poor that the positive-only NNLS solves the linear
+    # source intensity to zero, which makes every source-shape gradient legitimately
+    # zero — the comparison would then never exercise gradient flow through the
+    # source. Values mirror scripts/jax_likelihood_functions/imaging/simulator.py.
+    overrides = {
+        # The lens bulge's prior-median effective_radius is ~15", which floods the
+        # whole 3" mask and lets the (linear) bulge absorb the source arcs — NNLS
+        # then zeroes the source amplitude. Pin the bulge to truth-scale values.
+        "galaxies.lens.bulge.effective_radius": 0.6,
+        "galaxies.lens.bulge.sersic_index": 3.0,
+        "galaxies.lens.mass.centre_0": 0.01,
+        "galaxies.lens.mass.centre_1": 0.01,
+        "galaxies.lens.mass.ell_comps_0": al.convert.ell_comps_from(
+            axis_ratio=0.8, angle=45.0
+        )[0],
+        "galaxies.lens.mass.ell_comps_1": al.convert.ell_comps_from(
+            axis_ratio=0.8, angle=45.0
+        )[1],
+        "galaxies.lens.mass.einstein_radius": 1.6,
+        "galaxies.lens.mass.slope": 2.0,
+        "galaxies.source.bulge.centre_0": 0.1,
+        "galaxies.source.bulge.centre_1": 0.1,
+        "galaxies.source.bulge.ell_comps_0": al.convert.ell_comps_from(
+            axis_ratio=0.8, angle=60.0
+        )[0],
+        "galaxies.source.bulge.ell_comps_1": al.convert.ell_comps_from(
+            axis_ratio=0.8, angle=60.0
+        )[1],
+        "galaxies.source.bulge.effective_radius": 1.0,
+        "galaxies.source.bulge.sersic_index": 1.0,
+    }
+    param_names = util.parameter_names_from(model)
+    param_vector = np.array(param_vector)
+    for name, value in overrides.items():
+        if name in param_names:
+            param_vector[param_names.index(name)] = value
+    param_vector = jnp.array(param_vector)
+
+    value, grad = jax.value_and_grad(fitness.call)(param_vector)
+
+    print(f"Log likelihood = {float(value):.6f}")
+    print(f"Gradient shape = {grad.shape}")
+
+    assert np.isfinite(float(value)), "Log likelihood is not finite"
+    assert grad.shape == (
+        model.total_free_parameters,
+    ), f"Gradient shape mismatch: {grad.shape}"
+    assert np.all(
+        np.isfinite(np.array(grad))
+    ), f"Gradient contains non-finite values: {np.array(grad)}"
+    assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+    """
+    __Finite-Difference Correctness__
+    """
+    f_jit = jax.jit(fitness.call)
+
+    util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+    comparison = util.compare_gradients(
+        fitness.call,
+        param_vector,
+        param_names=param_names,
+        f_fd=f_jit,
+    )
+
+    util.assert_gradients_match(comparison)
+
+    # Guard against a silently dead source component (see the anchoring comment
+    # above): the source-shape gradients must actually be non-zero here.
+    source_indices = [
+        i for i, name in enumerate(param_names) if "galaxies.source" in name
+    ]
+    assert np.any(
+        np.abs(comparison["ad"][source_indices]) > 1e-3
+    ), "All source-parameter gradients are ~zero — NNLS zeroed the source; move the evaluation point."
+
+    print(f"{variant}: autodiff matches finite differences.")
+
+print("\nimaging_lp.py JAX gradient checks passed.")

--- a/scripts/jax_grad/imaging_mge.py
+++ b/scripts/jax_grad/imaging_mge.py
@@ -1,7 +1,21 @@
 """
-Tests that jax.value_and_grad can compute finite, non-NaN gradients of the log-likelihood
-for an imaging model with parametric light profiles. This tests the core JAX differentiability
-that enables gradient-based inference.
+Tests JAX gradients of the imaging log-likelihood for a Multi-Gaussian
+Expansion (MGE) source model, in two stages:
+
+ 1. Finiteness — ``jax.value_and_grad`` returns a finite log-likelihood and a
+    finite, non-zero gradient vector (the original check).
+ 2. Correctness — the autodiff gradient agrees with central finite differences
+    parameter-by-parameter (see ``util.py``).
+
+Because the MGE model uses only linear light profiles (``lp_linear.Gaussian``),
+there is no non-linear intensity parameter — all light is reconstructed via the
+linear inversion (positive-only NNLS solve), so this also exercises gradient
+flow through the inversion.
+
+Autodiff runs on the eager (un-jitted) likelihood; the finite-difference
+evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
+consistency check at the base point so ``pure_callback`` constant-folding
+cannot fake the comparison.
 """
 
 import numpy as np
@@ -12,7 +26,9 @@ from os import path
 import autofit as af
 import autolens as al
 
-dataset_name = "source_complex"
+import util
+
+dataset_name = "jax_test"
 dataset_path = path.join("dataset", "imaging", dataset_name)
 
 """
@@ -21,7 +37,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not path.exists(dataset_path):
+if al.util.dataset.should_simulate(dataset_path):
     import subprocess
     import sys
 
@@ -34,7 +50,7 @@ dataset = al.Imaging.from_fits(
     data_path=path.join(dataset_path, "data.fits"),
     psf_path=path.join(dataset_path, "psf.fits"),
     noise_map_path=path.join(dataset_path, "noise_map.fits"),
-    pixel_scales=0.05,
+    pixel_scales=0.2,
 )
 
 mask_radius = 3.5
@@ -120,5 +136,21 @@ assert np.all(
     np.isfinite(np.array(grad))
 ), f"Gradient contains non-finite values: {np.array(grad)}"
 assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+"""
+__Finite-Difference Correctness__
+"""
+f_jit = jax.jit(fitness.call)
+
+util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+comparison = util.compare_gradients(
+    fitness.call,
+    param_vector,
+    param_names=util.parameter_names_from(model),
+    f_fd=f_jit,
+)
+
+util.assert_gradients_match(comparison)
 
 print("imaging_mge.py JAX gradient checks passed.")

--- a/scripts/jax_grad/imaging_pixelization.py
+++ b/scripts/jax_grad/imaging_pixelization.py
@@ -8,6 +8,18 @@ parameter and autodiff agrees with central finite differences across the
 board (validated: AD = FD to 7 significant figures, stable over FD step
 sizes 1e-7..1e-5). The strict FD comparison runs on all parameters.
 
+**Variant C — ``RectangularAdaptImage`` (production config)** and
+**Variant D — ``RectangularAdaptDensity``, both at pixelization over-sampling 4**:
+with over-sampling > 1 (how these meshes are used in production) the
+interpolation queries no longer coincide with the transform knots, so sub-pixel
+strain carries a genuine smooth mass signal and every parameter's gradient is
+live and FD-matched. Variant C runs the full production shape: ``reg.Adapt()``,
+``al.AdaptImages``, and the border relocator. Tolerances are looser (5%) than
+the smooth variants because the finite differences — not autodiff — are
+contaminated by micro-staircase jumps from rank re-orderings; the measured
+FD-vs-step-size drift (2026-07-09) confirms FD converges toward autodiff as
+h → 0. Mixed precision is deliberately off: float64 is required for FD.
+
 **Variant B — ``RectangularAdaptDensity`` (pixelization over-sampling 1)**:
 the adaptive mesh maps ray-traced points to rank space via a sort +
 ``jnp.interp`` CDF transform (`create_transforms` — the "ray-guided
@@ -76,12 +88,7 @@ mask = al.Mask2D.circular(
     radius=mask_radius,
 )
 
-dataset = dataset.apply_mask(mask=mask)
-
-dataset = dataset.apply_over_sampling(
-    over_sample_size_lp=4,
-    over_sample_size_pixelization=1,
-)
+dataset_masked = dataset.apply_mask(mask=mask)
 
 """
 __Model__
@@ -94,7 +101,7 @@ source arcs land on the mesh and every parameter has likelihood sensitivity.
 """
 
 
-def model_from(mesh):
+def model_from(mesh, regularization=None):
     lens_bulge = af.Model(al.lp.Sersic)
     lens_bulge.centre.centre_0 = af.GaussianPrior(mean=0.0, sigma=0.005)
     lens_bulge.centre.centre_1 = af.GaussianPrior(mean=0.0, sigma=0.005)
@@ -125,9 +132,12 @@ def model_from(mesh):
         shear=shear,
     )
 
+    if regularization is None:
+        regularization = al.reg.Constant(coefficient=1.0)
+
     pixelization = al.Pixelization(
         mesh=mesh,
-        regularization=al.reg.Constant(coefficient=1.0),
+        regularization=regularization,
     )
 
     source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
@@ -138,9 +148,29 @@ def model_from(mesh):
 from autofit.non_linear.fitness import Fitness
 
 
-def fitness_and_params(mesh):
-    model = model_from(mesh=mesh)
-    analysis = al.AnalysisImaging(dataset=dataset)
+def fitness_and_params(mesh, regularization=None, os_pix=1, production_settings=False):
+    dataset = dataset_masked.apply_over_sampling(
+        over_sample_size_lp=4,
+        over_sample_size_pixelization=os_pix,
+    )
+    model = model_from(mesh=mesh, regularization=regularization)
+    analysis_kwargs = {}
+    if production_settings:
+        analysis_kwargs["adapt_images"] = al.AdaptImages(
+            galaxy_name_image_dict={
+                "('galaxies', 'lens')": dataset.data,
+                "('galaxies', 'source')": dataset.data,
+            }
+        )
+        analysis_kwargs["settings"] = al.Settings(
+            use_border_relocator=True,
+            use_positive_only_solver=True,
+        )
+    analysis = al.AnalysisImaging(
+        dataset=dataset,
+        raise_inversion_positions_likelihood_exception=False,
+        **analysis_kwargs,
+    )
     fitness = Fitness(
         model=model,
         analysis=analysis,
@@ -256,5 +286,61 @@ print(
     "RectangularAdaptDensity: lens-light gradients FD-matched; mass/shear "
     "staircase invariance confirmed (autodiff zero is correct)."
 )
+
+"""
+__Variants C + D: adaptive meshes at production over-sampling (os_pix=4)__
+
+The FD step is small (rel 1e-7) to stay below the rank-reordering scale, and the
+tolerance (5%) reflects the residual micro-staircase contamination of the finite
+differences — autodiff is the h-consistent reference here (FD drifts toward it as
+h shrinks).
+"""
+for variant, mesh, regularization, production_settings in [
+    (
+        "RectangularAdaptImage + reg.Adapt + adapt images + border relocator (os_pix=4)",
+        al.mesh.RectangularAdaptImage(shape=mesh_shape, weight_power=1.0),
+        al.reg.Adapt(),
+        True,
+    ),
+    (
+        "RectangularAdaptDensity (os_pix=4)",
+        al.mesh.RectangularAdaptDensity(shape=mesh_shape),
+        None,
+        False,
+    ),
+]:
+    print(f"\n=== {variant} ===")
+
+    fitness, param_vector, param_names = fitness_and_params(
+        mesh=mesh,
+        regularization=regularization,
+        os_pix=4,
+        production_settings=production_settings,
+    )
+
+    grad = finiteness_checks(fitness, param_vector, n_params=len(param_names))
+
+    f_jit = jax.jit(fitness.call)
+
+    util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+    comparison = util.compare_gradients(
+        fitness.call,
+        param_vector,
+        param_names=param_names,
+        rel_step=1e-7,
+        f_fd=f_jit,
+    )
+
+    util.assert_gradients_match(comparison, rtol=0.05, atol=1.0)
+
+    # Every parameter — including mass and shear — must be live at production
+    # over-sampling: this is the configuration gradient-based inference will use.
+    assert np.all(np.abs(comparison["ad"]) > 1.0), (
+        "A parameter gradient is ~zero at os_pix=4 — the adaptive mesh has lost "
+        f"smooth sensitivity: {[(n, a) for n, a in zip(param_names, comparison['ad']) if abs(a) <= 1.0]}"
+    )
+
+    print(f"{variant}: all gradients live and FD-matched (5% tolerance).")
 
 print("\nimaging_pixelization.py JAX gradient checks passed.")

--- a/scripts/jax_grad/imaging_pixelization.py
+++ b/scripts/jax_grad/imaging_pixelization.py
@@ -1,0 +1,260 @@
+"""
+Tests JAX gradients of the imaging log-likelihood for rectangular-mesh
+pixelized sources, encoding the 2026-07 gradient-audit verdict
+(autolens_workspace_developer#87) as assertions:
+
+**Variant A — ``RectangularUniform``**: the likelihood is smooth in every
+parameter and autodiff agrees with central finite differences across the
+board (validated: AD = FD to 7 significant figures, stable over FD step
+sizes 1e-7..1e-5). The strict FD comparison runs on all parameters.
+
+**Variant B — ``RectangularAdaptDensity`` (pixelization over-sampling 1)**:
+the adaptive mesh maps ray-traced points to rank space via a sort +
+``jnp.interp`` CDF transform (`create_transforms` — the "ray-guided
+transformed uniform grid" of arXiv:2606.30620). With pixelization
+over-sampling 1 the interpolation queries coincide with the knots, so the
+mapping — and therefore the likelihood — is **exactly invariant** under any
+order-preserving deformation of the traced grid. Consequences this script
+asserts:
+
+ - lens *light* parameters are smooth and FD-matched (they bypass the mesh);
+ - the likelihood is bit-identical under sub-reordering mass perturbations
+   (the staircase plateau), so autodiff's ~zero mass/shear gradients are the
+   *correct* almost-everywhere derivative — larger FD steps measure discrete
+   rank-reordering jumps, not a slope.
+
+Gradient-based mass inference is therefore impossible in this configuration —
+not because autodiff is wrong, but because the discretisation destroys smooth
+mass information. With pixelization over-sampling > 1 a genuine smooth mass
+gradient reappears (sub-pixel strain between queries and knots) and autodiff
+tracks it (AD ≈ FD(h→1e-7) within a few %, measured 2026-07-09); that
+configuration is documented in the audit README rather than asserted here to
+keep this script's runtime and semantics crisp.
+
+If a future library change makes the adaptive mesh differentiable in the mass
+parameters (e.g. a continuous density transform), variant B's invariance
+assertion will fail loudly — update it and the audit README together.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autolens as al
+
+import util
+
+dataset_name = "jax_test"
+dataset_path = path.join("dataset", "imaging", dataset_name)
+
+"""
+__Dataset Auto-Simulation__
+"""
+if al.util.dataset.should_simulate(dataset_path):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/imaging/simulator.py"],
+        check=True,
+    )
+
+dataset = al.Imaging.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    psf_path=path.join(dataset_path, "psf.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    pixel_scales=0.2,
+)
+
+mask_radius = 3.5
+
+mask = al.Mask2D.circular(
+    shape_native=dataset.shape_native,
+    pixel_scales=dataset.pixel_scales,
+    radius=mask_radius,
+)
+
+dataset = dataset.apply_mask(mask=mask)
+
+dataset = dataset.apply_over_sampling(
+    over_sample_size_lp=4,
+    over_sample_size_pixelization=1,
+)
+
+"""
+__Model__
+
+Truth-centred Gaussian priors (mirroring the developer probe
+``jax_profiling/gradient/imaging/pixelization.py``) keep the evaluation point in a
+non-degenerate region: the jax_test simulator truth is an Isothermal at
+einstein_radius=1.6 / q=0.8 / 45deg with a small shear, so at prior medians the
+source arcs land on the mesh and every parameter has likelihood sensitivity.
+"""
+
+
+def model_from(mesh):
+    lens_bulge = af.Model(al.lp.Sersic)
+    lens_bulge.centre.centre_0 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    lens_bulge.centre.centre_1 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    bulge_ell = al.convert.ell_comps_from(axis_ratio=0.9, angle=45.0)
+    lens_bulge.ell_comps.ell_comps_0 = af.GaussianPrior(mean=bulge_ell[0], sigma=0.01)
+    lens_bulge.ell_comps.ell_comps_1 = af.GaussianPrior(mean=bulge_ell[1], sigma=0.01)
+    lens_bulge.intensity = af.GaussianPrior(mean=2.0, sigma=0.1)
+    lens_bulge.effective_radius = af.GaussianPrior(mean=0.6, sigma=0.05)
+    lens_bulge.sersic_index = af.GaussianPrior(mean=3.0, sigma=0.2)
+
+    mass = af.Model(al.mp.Isothermal)
+    mass.centre.centre_0 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    mass.centre.centre_1 = af.GaussianPrior(mean=0.0, sigma=0.005)
+    mass.einstein_radius = af.GaussianPrior(mean=1.6, sigma=0.05)
+    mass_ell = al.convert.ell_comps_from(axis_ratio=0.8, angle=45.0)
+    mass.ell_comps.ell_comps_0 = af.GaussianPrior(mean=mass_ell[0], sigma=0.01)
+    mass.ell_comps.ell_comps_1 = af.GaussianPrior(mean=mass_ell[1], sigma=0.01)
+
+    shear = af.Model(al.mp.ExternalShear)
+    shear.gamma_1 = af.GaussianPrior(mean=0.001, sigma=0.005)
+    shear.gamma_2 = af.GaussianPrior(mean=0.001, sigma=0.005)
+
+    lens = af.Model(
+        al.Galaxy,
+        redshift=0.5,
+        bulge=lens_bulge,
+        mass=mass,
+        shear=shear,
+    )
+
+    pixelization = al.Pixelization(
+        mesh=mesh,
+        regularization=al.reg.Constant(coefficient=1.0),
+    )
+
+    source = af.Model(al.Galaxy, redshift=1.0, pixelization=pixelization)
+
+    return af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+
+from autofit.non_linear.fitness import Fitness
+
+
+def fitness_and_params(mesh):
+    model = model_from(mesh=mesh)
+    analysis = al.AnalysisImaging(dataset=dataset)
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+    param_vector = jnp.array(model.physical_values_from_prior_medians)
+    # Small perturbation off the exact prior medians (avoids symmetric special
+    # points, e.g. mass centre exactly on a grid point).
+    key = jax.random.PRNGKey(42)
+    perturbation = jax.random.uniform(
+        key, shape=param_vector.shape, minval=0.001, maxval=0.005
+    )
+    param_vector = param_vector + perturbation
+    param_names = util.parameter_names_from(model)
+    return fitness, param_vector, param_names
+
+
+def finiteness_checks(fitness, param_vector, n_params):
+    value, grad = jax.value_and_grad(fitness.call)(param_vector)
+    print(f"Log likelihood = {float(value):.6f}")
+    assert np.isfinite(float(value)), "Log likelihood is not finite"
+    assert grad.shape == (n_params,), f"Gradient shape mismatch: {grad.shape}"
+    assert np.all(
+        np.isfinite(np.array(grad))
+    ), f"Gradient contains non-finite values: {np.array(grad)}"
+    assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+    return grad
+
+
+"""
+__Variant A: RectangularUniform — strict FD correctness on all parameters__
+"""
+print("\n=== RectangularUniform (os_pix=1) ===")
+
+mesh_shape = (28, 28)
+
+fitness, param_vector, param_names = fitness_and_params(
+    mesh=al.mesh.RectangularUniform(shape=mesh_shape)
+)
+
+finiteness_checks(fitness, param_vector, n_params=len(param_names))
+
+f_jit = jax.jit(fitness.call)
+
+util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+comparison = util.compare_gradients(
+    fitness.call,
+    param_vector,
+    param_names=param_names,
+    f_fd=f_jit,
+)
+
+util.assert_gradients_match(comparison)
+
+print("RectangularUniform: autodiff matches finite differences on all parameters.")
+
+"""
+__Variant B: RectangularAdaptDensity — smooth lens light, staircase mass__
+"""
+print("\n=== RectangularAdaptDensity (os_pix=1) ===")
+
+fitness, param_vector, param_names = fitness_and_params(
+    mesh=al.mesh.RectangularAdaptDensity(shape=mesh_shape)
+)
+
+grad = finiteness_checks(fitness, param_vector, n_params=len(param_names))
+
+f_jit = jax.jit(fitness.call)
+
+util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+light_indices = [i for i, n in enumerate(param_names) if ".bulge." in n]
+mass_indices = [
+    i for i, n in enumerate(param_names) if ".mass." in n or ".shear." in n
+]
+
+# Lens-light parameters bypass the adaptive mesh: strict FD comparison.
+comparison = util.compare_gradients(
+    fitness.call,
+    param_vector,
+    param_names=param_names,
+    f_fd=f_jit,
+)
+
+util.assert_gradients_match(comparison, skip_indices=mass_indices)
+
+# Mass/shear parameters: the likelihood must be *exactly* flat under
+# sub-reordering perturbations (the staircase plateau) — this is why autodiff's
+# ~zero gradients are correct, and it is the property that makes gradient-based
+# mass inference impossible in this configuration.
+base_value = float(f_jit(param_vector))
+i_er = param_names.index("galaxies.lens.mass.einstein_radius")
+for h in [1e-7, 1e-6]:
+    for sign in [+1.0, -1.0]:
+        shifted = np.array(param_vector)
+        shifted[i_er] += sign * h
+        shifted_value = float(f_jit(jnp.array(shifted)))
+        assert shifted_value == base_value, (
+            f"Likelihood changed under einstein_radius shift of {sign * h:+.0e} "
+            f"({shifted_value} != {base_value}) — the adaptive mesh has become "
+            "sensitive to smooth mass perturbations; re-run the full FD audit and "
+            "update this script + the audit README."
+        )
+
+assert np.all(np.abs(np.array(grad)[mass_indices]) < 1e-6), (
+    "Autodiff mass/shear gradients are no longer ~zero — the adaptive mesh "
+    "differentiability picture has changed; re-run the full FD audit."
+)
+
+print(
+    "RectangularAdaptDensity: lens-light gradients FD-matched; mass/shear "
+    "staircase invariance confirmed (autodiff zero is correct)."
+)
+
+print("\nimaging_pixelization.py JAX gradient checks passed.")

--- a/scripts/jax_grad/point_source.py
+++ b/scripts/jax_grad/point_source.py
@@ -1,0 +1,172 @@
+"""
+Tests JAX gradients of the point-source **source-plane** chi-squared
+(``al.FitPositionsSource``), in two stages:
+
+ 1. Finiteness — ``jax.value_and_grad`` returns a finite log-likelihood and a
+    finite, non-zero gradient vector.
+ 2. Correctness — the autodiff gradient agrees with central finite differences
+    parameter-by-parameter (see ``util.py``).
+
+The source-plane likelihood ray-traces the observed image-plane positions to
+the source plane and penalises their distance to the modelled source centre,
+weighted by per-position magnifications computed from the Hessian of the
+deflection field — so this validates second-derivative flow through the mass
+profiles.
+
+Notable: the forward ``jax.jit`` of this likelihood is blocked
+(``Grid2DIrregular.grid_2d_via_deflection_grid_from`` does not propagate
+``xp``), but ``jax.value_and_grad`` succeeds — the gradient path is usable by
+samplers today even though the jitted forward pass is not. Because of that,
+the finite-difference sweep here uses the eager likelihood (no jit), unlike
+the imaging scripts.
+
+Parameters with no positional information (``point_0.flux``, ``H0``) have
+legitimately zero gradients — both autodiff and finite differences agree on
+zero, and the script asserts the positional parameters are live.
+
+Setup mirrors ``scripts/jax_likelihood_functions/point_source/source_plane.py``.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+
+import util
+
+"""
+__Dataset__
+"""
+dataset_name = "simple"
+dataset_path = Path("dataset") / "point_source" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+"""
+if al.util.dataset.should_simulate(str(dataset_path)):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/point_source/simulator.py"],
+        check=True,
+    )
+
+dataset = al.from_json(
+    file_path=dataset_path / "point_dataset_positions_only.json",
+)
+
+"""
+__Point Solver__
+
+Source-plane chi-squared does not use the solver, but ``AnalysisPoint``
+requires one — pass the standard JAX-friendly solver for consistency.
+"""
+grid = al.Grid2D.uniform(
+    shape_native=(100, 100),
+    pixel_scales=0.2,
+)
+
+solver = al.PointSolver.for_grid(
+    grid=grid, pixel_scale_precision=0.001, magnification_threshold=0.1
+)
+
+"""
+__Model__
+"""
+mass = af.Model(al.mp.Isothermal)
+
+mass.centre.centre_0 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+mass.ell_comps.ell_comps_0 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.8)
+
+lens = af.Model(al.Galaxy, redshift=0.5, mass=mass)
+
+point_0 = af.Model(al.ps.PointFlux)
+point_0.centre.centre_0 = af.UniformPrior(lower_limit=0.06, upper_limit=0.08)
+point_0.centre.centre_1 = af.UniformPrior(lower_limit=0.06, upper_limit=0.08)
+
+source = af.Model(al.Galaxy, redshift=1.0, point_0=point_0)
+
+cosmology = af.Model(al.cosmo.FlatLambdaCDM)
+cosmology.H0 = af.UniformPrior(lower_limit=0.0, upper_limit=150.0)
+
+model = af.Collection(
+    galaxies=af.Collection(lens=lens, source=source), cosmology=cosmology
+)
+
+print(model.info)
+
+"""
+__Analysis__
+"""
+analysis = al.AnalysisPoint(
+    dataset=dataset,
+    solver=solver,
+    fit_positions_cls=al.FitPositionsSource,
+)
+
+from autofit.non_linear.fitness import Fitness
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+param_vector = jnp.array(model.physical_values_from_prior_medians)
+
+key = jax.random.PRNGKey(42)
+perturbation = jax.random.uniform(
+    key, shape=param_vector.shape, minval=0.001, maxval=0.005
+)
+param_vector = param_vector + perturbation
+
+value, grad = jax.value_and_grad(fitness.call)(param_vector)
+
+print(f"Log likelihood = {float(value):.6f}")
+print(f"Gradient shape = {grad.shape}")
+
+assert np.isfinite(float(value)), "Log likelihood is not finite"
+assert grad.shape == (
+    model.total_free_parameters,
+), f"Gradient shape mismatch: {grad.shape}"
+assert np.all(
+    np.isfinite(np.array(grad))
+), f"Gradient contains non-finite values: {np.array(grad)}"
+assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+"""
+__Finite-Difference Correctness__
+
+Eager evaluation throughout — the forward jit of this likelihood is blocked
+(see module docstring), which the FD sweep tolerates because the positions
+dataset is tiny.
+"""
+param_names = util.parameter_names_from(model)
+
+comparison = util.compare_gradients(
+    fitness.call,
+    param_vector,
+    param_names=param_names,
+)
+
+util.assert_gradients_match(comparison)
+
+# The positional parameters (everything except flux and H0) must be live.
+positional_indices = [
+    i
+    for i, name in enumerate(param_names)
+    if "flux" not in name and "H0" not in name
+]
+assert np.all(
+    np.abs(comparison["ad"][positional_indices]) > 0.0
+), "A positional parameter has zero gradient — evaluation point is degenerate."
+
+print("point_source.py JAX gradient checks passed.")

--- a/scripts/jax_grad/util.py
+++ b/scripts/jax_grad/util.py
@@ -1,0 +1,145 @@
+"""
+Shared utilities for the ``jax_grad`` scripts: compare ``jax.grad`` of a scalar
+likelihood function against central finite differences, parameter by parameter.
+
+The scripts in this folder previously only asserted that gradients are finite
+and non-zero. Finiteness does not catch wrong gradients (e.g. terms silently
+dropped by ``lax.stop_gradient``, zeroed cotangents through frozen structures,
+or incorrect custom VJPs). These helpers make correctness checkable:
+
+- ``fd_gradient`` — central finite differences of ``f`` with a per-parameter
+  step scaled to the parameter's magnitude. Requires float64 (the default in
+  this stack) — float32 finite differences are dominated by round-off.
+- ``compare_gradients`` — evaluates autodiff and finite differences, prints a
+  per-parameter table and returns the arrays plus error metrics.
+- ``assert_gradients_match`` — the assertion used by the scripts. A parameter
+  passes if ``|ad - fd| <= atol + rtol * max(|ad|, |fd|)``. Parameters whose
+  gradient is *intentionally* approximate (documented ``stop_gradient``
+  drops) can be excluded via ``skip_indices`` — the point is that every
+  exclusion is explicit and visible in the calling script, never hidden by a
+  loose global tolerance.
+
+Evaluation honesty: ``f`` is evaluated eagerly (no ``jax.jit``) by default.
+Under a single JIT trace, ``jax.pure_callback`` results can be constant-folded
+into the compiled program, which fakes both values and (zero) gradients. If a
+jitted ``f`` is passed for speed, call ``assert_eager_jit_consistent`` first
+with the un-jitted function so the two agree at the base point.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+
+def parameter_names_from(model):
+    """
+    Human-readable parameter names for a PyAutoFit model, used to label the
+    comparison table. Falls back to indices if the API is unavailable.
+    """
+    try:
+        return list(model.model_component_and_parameter_names)
+    except AttributeError:
+        return None
+
+
+def fd_gradient(f, x, rel_step=1e-5, abs_floor=0.1):
+    """
+    Central finite-difference gradient of the scalar function ``f`` at ``x``.
+
+    The step for parameter ``i`` is ``rel_step * max(|x_i|, abs_floor)`` so
+    that parameters of very different magnitude (ell_comps ~0.05, Einstein
+    radius ~1.6) each get a sensibly scaled perturbation.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    if x.dtype != np.float64:
+        raise ValueError("fd_gradient requires float64 parameters.")
+    grad = np.zeros_like(x)
+    for i in range(x.size):
+        h = rel_step * max(abs(x[i]), abs_floor)
+        x_plus = x.copy()
+        x_plus[i] += h
+        x_minus = x.copy()
+        x_minus[i] -= h
+        f_plus = float(f(jnp.array(x_plus)))
+        f_minus = float(f(jnp.array(x_minus)))
+        grad[i] = (f_plus - f_minus) / (2.0 * h)
+    return grad
+
+
+def compare_gradients(f, x, param_names=None, rel_step=1e-5, abs_floor=0.1, f_fd=None):
+    """
+    Compute autodiff and finite-difference gradients of ``f`` at ``x`` and
+    print a per-parameter comparison table.
+
+    ``f_fd`` optionally supplies a faster (e.g. jitted) function for the
+    ``2 * n_params`` finite-difference evaluations while autodiff runs on the
+    eager ``f``; guard it with ``assert_eager_jit_consistent`` first.
+
+    Returns a dict with ``ad``, ``fd``, ``abs_err`` and ``rel_err`` arrays,
+    where ``rel_err = abs_err / max(|ad|, |fd|)`` (0 where both are 0).
+    """
+    x = jnp.asarray(x)
+    ad = np.array(jax.grad(f)(x))
+    fd = fd_gradient(
+        f_fd if f_fd is not None else f,
+        np.array(x),
+        rel_step=rel_step,
+        abs_floor=abs_floor,
+    )
+
+    abs_err = np.abs(ad - fd)
+    denom = np.maximum(np.abs(ad), np.abs(fd))
+    rel_err = np.divide(abs_err, denom, out=np.zeros_like(abs_err), where=denom > 0)
+
+    if param_names is None:
+        param_names = [f"p[{i}]" for i in range(len(ad))]
+    name_width = max(len(name) for name in param_names)
+
+    print(
+        f"\n{'parameter':<{name_width}}  {'autodiff':>14}  {'finite diff':>14}"
+        f"  {'abs err':>10}  {'rel err':>10}"
+    )
+    for name, a, d, ae, re in zip(param_names, ad, fd, abs_err, rel_err):
+        print(
+            f"{name:<{name_width}}  {a:>14.6e}  {d:>14.6e}  {ae:>10.3e}  {re:>10.3e}"
+        )
+
+    return {"ad": ad, "fd": fd, "abs_err": abs_err, "rel_err": rel_err}
+
+
+def assert_gradients_match(comparison, rtol=1e-3, atol=1e-4, skip_indices=()):
+    """
+    Assert autodiff and finite differences agree parameter-wise:
+    ``|ad - fd| <= atol + rtol * max(|ad|, |fd|)``.
+
+    ``skip_indices`` names parameters whose autodiff gradient is knowingly
+    approximate (each exclusion must be justified by a comment at the call
+    site). The skipped parameters are still printed by ``compare_gradients``
+    so the deviation stays measured and visible.
+    """
+    ad, fd, abs_err = comparison["ad"], comparison["fd"], comparison["abs_err"]
+    tol = atol + rtol * np.maximum(np.abs(ad), np.abs(fd))
+    failures = [
+        i
+        for i in range(len(ad))
+        if i not in set(skip_indices) and abs_err[i] > tol[i]
+    ]
+    assert not failures, (
+        f"Autodiff vs finite-difference mismatch at parameter indices {failures}: "
+        f"ad={ad[failures]}, fd={fd[failures]}, abs_err={abs_err[failures]}, "
+        f"tolerance={tol[failures]}"
+    )
+
+
+def assert_eager_jit_consistent(f_eager, f_jit, x, rtol=1e-10):
+    """
+    Guard against ``pure_callback`` constant-folding: a jitted likelihood must
+    agree with the eager likelihood at the same point before its gradients can
+    be trusted for comparison work.
+    """
+    v_eager = float(f_eager(jnp.asarray(x)))
+    v_jit = float(f_jit(jnp.asarray(x)))
+    assert np.isclose(v_eager, v_jit, rtol=rtol), (
+        f"Eager ({v_eager}) and jitted ({v_jit}) evaluations disagree — "
+        "possible pure_callback constant-folding; do not trust jitted gradients."
+    )

--- a/scripts/jax_grad/weak.py
+++ b/scripts/jax_grad/weak.py
@@ -1,0 +1,137 @@
+"""
+Tests JAX gradients of the weak-lensing shear log-likelihood (``FitWeak`` via
+``al.AnalysisWeak(use_jax=True)``), in two stages:
+
+ 1. Finiteness — ``jax.value_and_grad`` returns a finite log-likelihood and a
+    finite, non-zero gradient vector.
+ 2. Correctness — the autodiff gradient agrees with central finite differences
+    parameter-by-parameter (see ``util.py``).
+
+The model shear is derived from the tracer's mass profiles via
+``LensCalc.shear_yx_2d_via_hessian_from``, so the gradient flows through the
+Hessian of the deflection field. Both the plain likelihood and the per-galaxy
+redshift-scaled (sigma_crit scaling) variant are checked — the scale factors
+are concrete constants computed outside the trace, so they must not disturb
+gradient flow.
+
+Setup mirrors ``scripts/jax_likelihood_functions/weak/shear.py`` (the value
+parity script for PyAutoLens feature/weak-sigma-crit-jax, issue #590).
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from pathlib import Path
+
+import autofit as af
+import autolens as al
+
+import util
+
+"""
+__Dataset__
+"""
+dataset_path = Path("dataset") / "weak" / "simple"
+
+"""
+__Dataset Auto-Simulation__
+"""
+if al.util.dataset.should_simulate(str(dataset_path)):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/weak/simulator.py"],
+        check=True,
+    )
+
+dataset = al.from_json(file_path=dataset_path / "dataset.json")
+
+"""
+__Model__
+"""
+
+
+def model_from():
+    mass = af.Model(al.mp.Isothermal)
+
+    mass.centre.centre_0 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+    mass.centre.centre_1 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+    mass.ell_comps.ell_comps_0 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+    mass.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=0.0, upper_limit=0.02)
+    mass.einstein_radius = af.UniformPrior(lower_limit=1.5, upper_limit=1.8)
+
+    lens = af.Model(al.Galaxy, redshift=0.5, mass=mass)
+
+    source = af.Model(al.Galaxy, redshift=1.0)
+
+    return af.Collection(galaxies=af.Collection(lens=lens, source=source))
+
+
+"""
+__Redshift-scaled variant dataset__
+
+Per-galaxy sigma_crit scaling: concrete per-dataset constants computed before any trace.
+"""
+redshifts = list(np.random.default_rng(2).uniform(0.6, 2.0, dataset.n_galaxies))
+dataset_scaled = al.WeakDataset(
+    shear_yx=dataset.shear_yx,
+    noise_map=dataset.noise_map,
+    name="simple_scaled",
+    redshifts=redshifts,
+)
+
+from autofit.non_linear.fitness import Fitness
+
+for variant, dataset_variant in [
+    ("weak shear", dataset),
+    ("weak shear, redshift-scaled", dataset_scaled),
+]:
+    print(f"\n=== {variant} ===")
+
+    model = model_from()
+
+    analysis = al.AnalysisWeak(dataset=dataset_variant, use_jax=True)
+
+    fitness = Fitness(
+        model=model,
+        analysis=analysis,
+        fom_is_log_likelihood=True,
+        resample_figure_of_merit=-1.0e99,
+    )
+
+    param_vector = jnp.array(model.physical_values_from_prior_medians)
+
+    value, grad = jax.value_and_grad(fitness.call)(param_vector)
+
+    print(f"Log likelihood = {float(value):.6f}")
+    print(f"Gradient shape = {grad.shape}")
+
+    assert np.isfinite(float(value)), "Log likelihood is not finite"
+    assert grad.shape == (
+        model.total_free_parameters,
+    ), f"Gradient shape mismatch: {grad.shape}"
+    assert np.all(
+        np.isfinite(np.array(grad))
+    ), f"Gradient contains non-finite values: {np.array(grad)}"
+    assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+    """
+    __Finite-Difference Correctness__
+    """
+    f_jit = jax.jit(fitness.call)
+
+    util.assert_eager_jit_consistent(fitness.call, f_jit, param_vector)
+
+    comparison = util.compare_gradients(
+        fitness.call,
+        param_vector,
+        param_names=util.parameter_names_from(model),
+        f_fd=f_jit,
+    )
+
+    util.assert_gradients_match(comparison)
+
+    print(f"{variant}: autodiff matches finite differences.")
+
+print("\nweak.py JAX gradient checks passed.")


### PR DESCRIPTION
Part of the JAX autodiff gradients audit — PyAutoLabs/autolens_workspace_developer#87.

Upgrades `scripts/jax_grad/` from finiteness-only checks to **autodiff-vs-finite-difference correctness**, and extends coverage to every differentiable PyAutoLens likelihood.

## Scripts Changed

- `scripts/jax_grad/util.py` (new) — shared FD comparison helpers: central differences with per-parameter scaled steps, autodiff on the eager likelihood + FD sweep on a jitted one guarded by an eager-vs-jit base-point check (anti-`pure_callback`-const-folding), explicit skip-list semantics.
- `scripts/jax_grad/imaging_lp.py` — standard `lp.Sersic` + `lp_linear.Sersic` variants, FD-validated (rel err ≤ 1e-5 / ≤ 3e-9). Evaluation point anchored near simulator truth so the positive-only NNLS keeps the source live; asserts the source block is live. Fixes the stale `imaging/simple` dataset pointer that broke the script on clean checkouts.
- `scripts/jax_grad/imaging_mge.py` — MGE source FD-validated through the linear inversion (rel err ≤ 5e-7). Fixes the stale `imaging/source_complex` pointer.
- `scripts/jax_grad/imaging_pixelization.py` (new) — `RectangularUniform`: strict FD assertions on all 14 params (AD = FD to 7 s.f.). `RectangularAdaptDensity` (os_pix=1): lens-light FD assertions + **staircase-invariance assertions** (LL bit-identical under ≤1e-6 mass shifts — autodiff's zero mass gradients are the correct a.e. derivative; fails loudly if mesh differentiability ever changes).
- `scripts/jax_grad/point_source.py` (new) — `FitPositionsSource` source-plane χ² FD-validated (rel err ≤ 5e-6, incl. magnification-via-Hessian); eager path (forward jit blocked upstream by the `Grid2DIrregular` xp gap).
- `scripts/jax_grad/weak.py` (new) — `FitWeak` FD-validated (rel err ≤ 3e-9), plain + per-galaxy redshift-scaled.

## Validation

All six scripts run green from the repo root on CPU JAX (float64), 2026-07-09, against current mains. Heart YELLOW acknowledged by the user at ship (pre-existing mcmc-smoke failures / worktree drift / assistant version skew — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGDp54jKUd3kUziTF77pNu