### PR TITLE
fix(viz): assert fit_quick.png, the real lens quick-update artifact

### DIFF
--- a/scripts/imaging/modeling_visualization_jit.py
+++ b/scripts/imaging/modeling_visualization_jit.py
@@ -302,19 +302,19 @@ print("Running Nautilus ...")
 result = search.fit(model=model_mge2, analysis=analysis_mge2)
 
 # The Nautilus output goes to output/<path_prefix>/<name>/<hash>/image/
-# The quick-update visualizer writes fit.png (via subplot_fit function)
+# The lens quick-update visualizer writes fit_quick.png (via subplot_fit_quick)
 # to that image folder during each quick update.
 output_search_root = Path("output") / output_root / "mge_linear"
-produced_pngs = list(output_search_root.rglob("fit.png"))
-print(f"fit.png files produced: {len(produced_pngs)}")
+produced_pngs = list(output_search_root.rglob("fit_quick.png"))
+print(f"fit_quick.png files produced: {len(produced_pngs)}")
 for p in produced_pngs:
     print(f"  {p}")
 assert len(produced_pngs) > 0, (
-    f"no fit.png produced under {output_search_root} — "
+    f"no fit_quick.png produced under {output_search_root} — "
     "quick-update visualization did not fire"
 )
 print(
     "\nPASS: jit-cached fit_for_visualization fires during Nautilus quick updates "
-    "with MGE linear profiles, fit.png written, no KeyError from "
+    "with MGE linear profiles, fit_quick.png written, no KeyError from "
     "linear_light_profile_intensity_dict lookup."
 )

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -311,17 +311,17 @@ print("Running Nautilus ...")
 result = search.fit(model=model_mge2, analysis=analysis_mge2)
 
 # The Nautilus output goes to output/<path_prefix>/<name>/<hash>/image/
-# The quick-update visualizer writes fit.png during each quick update.
-produced_pngs = list(output_search_root.rglob("fit.png"))
-print(f"fit.png files produced: {len(produced_pngs)}")
+# The lens quick-update visualizer writes fit_quick.png during each quick update.
+produced_pngs = list(output_search_root.rglob("fit_quick.png"))
+print(f"fit_quick.png files produced: {len(produced_pngs)}")
 for p in produced_pngs:
     print(f"  {p}")
 assert len(produced_pngs) > 0, (
-    f"no fit.png produced under {output_search_root} — "
+    f"no fit_quick.png produced under {output_search_root} — "
     "quick-update visualization did not fire"
 )
 print(
     "\nPASS: jit-cached fit_for_visualization fires during Nautilus quick updates "
-    "with MGE linear profiles, fit.png written, no KeyError from "
+    "with MGE linear profiles, fit_quick.png written, no KeyError from "
     "linear_light_profile_intensity_dict lookup."
 )

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -262,15 +262,16 @@ print("Running Nautilus ...")
 result = search.fit(model=model2, analysis=analysis_run)
 
 # Nautilus writes quick-update images to output/<path_prefix>/<name>/<hash>/image/
-produced_pngs = list(output_search_root.rglob("fit.png"))
-print(f"fit.png files produced: {len(produced_pngs)}")
+# The lens quick-update visualizer writes fit_quick.png (via subplot_fit_quick).
+produced_pngs = list(output_search_root.rglob("fit_quick.png"))
+print(f"fit_quick.png files produced: {len(produced_pngs)}")
 for p in produced_pngs:
     print(f"  {p}")
 assert len(produced_pngs) > 0, (
-    f"no fit.png produced under {output_search_root} — "
+    f"no fit_quick.png produced under {output_search_root} — "
     "quick-update visualization did not fire"
 )
 print(
     "\nPASS: jit-cached fit_for_visualization fires during Nautilus quick updates "
-    f"for point source, fit.png written."
+    f"for point source, fit_quick.png written."
 )


### PR DESCRIPTION
## Problem

`scripts/{imaging,interferometer,point_source}/modeling_visualization_jit.py` fail in the release-fidelity Workspace Validation matrix with:

```
AssertionError: no fit.png produced under output/.../modeling_visualization_jit/... — quick-update visualization did not fire
```

The Part-2 assertion globs `rglob("fit.png")`, but the **lens** quick-update visualizer writes **`fit_quick.png`** (via `subplot_fit_quick`, `output_filename="fit_quick"`), not `fit.png`. So the assertion failed deterministically even though quick-update fired correctly.

## Root cause

Verified against a real local Nautilus run of the imaging script: the search produces `output/.../mge_linear/<hash>/image/fit_quick.png` (+ `dataset.png`). `rglob("fit.png")` → 0 matches; `rglob("fit_quick.png")` → 1 match. The quick-update fired; the test looked for the wrong filename (library artifact name the test was never updated to).

## Fix

Update the glob, prints, assertion message and stale comments to `fit_quick.png` in the three lens scripts. Intent (verify quick-update fires and writes its fit subplot) is unchanged.

## Verification

`rglob("fit_quick.png")` finds the real artifact from the produced output tree (0 → 1). Full end-to-end run is gated on this laptop by the Part-1 hardware-dependent perf assertion (`warm_dt < 0.1`), which is unrelated to this fix and passes on the faster CI runners.

## Scope note

This covers only the **lens** scripts (autolens_workspace_test). The sibling `autogalaxy_workspace_test` imaging/interferometer scripts write `fit.png` (different plotter) yet also fail — that is a *different* root cause under investigation via a fresh validation run; ellipse likewise. Those are out of scope here.

pending-release