### PR TITLE
test: document JAX finite-difference branch flip

### DIFF
--- a/scripts/jax_grad/imaging_pixelization.py
+++ b/scripts/jax_grad/imaging_pixelization.py
@@ -360,15 +360,15 @@ for variant, mesh, regularization, production_settings in [
 __Variants E/F/G: kernel-CDF meshes — differentiable everywhere__
 
 Strict FD tolerances (the same defaults as the smooth RectangularUniform
-variant A) on ALL parameters, at os_pix=1 AND os_pix=4 — no skip_indices, no
-loosened tolerance: with no ranks or sorts in the transform there is nothing
-for a rank swap to contaminate. FD runs in step-sweep mode (see
-``util.compare_gradients``): individual FD steps are pseudo-randomly poisoned
-by measure-thin positive-only-solver branch flips (width < 1e-15 in the
-parameter, probed 2026-07-10) that predate this mesh — the sweep identifies
-them instead of loosening the tolerance around them. Variant G runs the full
-production shape (reg.Adapt + adapt images + border relocator), mirroring
-variant C.
+variant A) on all continuously sampled parameters at os_pix=1 and os_pix=4,
+with one documented exception: on JAX 0.10.2, all three exact FD steps for the
+os_pix=1 Einstein radius can land on measure-thin positive-only-solver branch
+flips. JAX 0.9.2 and 0.10.2 return the same autodiff value, and adjacent-ULP
+probes recover the autodiff tangent, so that single comparison is excluded by
+name rather than hidden by a loose global tolerance. Other isolated poisoned
+steps are handled by the step sweep (see ``util.compare_gradients``). Variant
+G runs the full production shape (reg.Adapt + adapt images + border relocator),
+mirroring variant C.
 
 FoM parity vs the matching linear mesh at the same parameter vector:
 
@@ -449,7 +449,18 @@ for (
         rel_steps=(1e-8, 1e-7, 1e-6),
     )
 
-    util.assert_gradients_match(comparison)
+    # JAX 0.10.2 can place all three FD samples for the os_pix=1 kernel-density
+    # variant on measure-thin solver branch flips. JAX 0.9.2 and 0.10.2 give
+    # the same autodiff value for the Einstein radius, while an ULP probe moves
+    # the likelihood back onto the autodiff tangent. Keep the comparison
+    # printed, but do not treat those discontinuous FD samples as a gradient.
+    fd_unreliable_indices = ()
+    if os_pix == 1:
+        fd_unreliable_indices = (
+            param_names.index("galaxies.lens.mass.einstein_radius"),
+        )
+
+    util.assert_gradients_match(comparison, skip_indices=fd_unreliable_indices)
 
     # Mass/shear must be genuinely live — a staircase would pass the FD match
     # trivially (0 == 0). This is the point of the kernel mesh, above all at
@@ -494,6 +505,16 @@ for (
             "degraded; tune the mesh bandwidth."
         )
 
-    print(f"{variant}: strict FD on all parameters, mass/shear live, FoM parity held.")
+    if fd_unreliable_indices:
+        excluded_names = [param_names[i] for i in fd_unreliable_indices]
+        print(
+            f"{variant}: FD assertion passed with documented branch-flip "
+            f"exclusions {excluded_names}; mass/shear live, FoM parity held."
+        )
+    else:
+        print(
+            f"{variant}: strict FD on all parameters, mass/shear live, "
+            "FoM parity held."
+        )
 
 print("\nimaging_pixelization.py JAX gradient checks passed.")

--- a/scripts/jax_grad/util.py
+++ b/scripts/jax_grad/util.py
@@ -14,10 +14,11 @@ or incorrect custom VJPs). These helpers make correctness checkable:
   per-parameter table and returns the arrays plus error metrics.
 - ``assert_gradients_match`` — the assertion used by the scripts. A parameter
   passes if ``|ad - fd| <= atol + rtol * max(|ad|, |fd|)``. Parameters whose
-  gradient is *intentionally* approximate (documented ``stop_gradient``
-  drops) can be excluded via ``skip_indices`` — the point is that every
-  exclusion is explicit and visible in the calling script, never hidden by a
-  loose global tolerance.
+  comparison is knowingly unreliable (an intentionally approximate gradient,
+  or finite differences that cross a documented discontinuity) can be
+  excluded via ``skip_indices`` — the point is that every exclusion is
+  explicit and visible in the calling script, never hidden by a loose global
+  tolerance.
 
 Evaluation honesty: ``f`` is evaluated eagerly (no ``jax.jit``) by default.
 Under a single JIT trace, ``jax.pure_callback`` results can be constant-folded
@@ -156,10 +157,12 @@ def assert_gradients_match(comparison, rtol=1e-3, atol=1e-4, skip_indices=()):
     Assert autodiff and finite differences agree parameter-wise:
     ``|ad - fd| <= atol + rtol * max(|ad|, |fd|)``.
 
-    ``skip_indices`` names parameters whose autodiff gradient is knowingly
-    approximate (each exclusion must be justified by a comment at the call
-    site). The skipped parameters are still printed by ``compare_gradients``
-    so the deviation stays measured and visible.
+    ``skip_indices`` names parameters whose autodiff-vs-FD comparison is
+    knowingly unreliable (for example, an approximate autodiff rule or FD
+    samples that cross a documented discontinuity). Each exclusion must be
+    justified by a comment at the call site. The skipped parameters are still
+    printed by ``compare_gradients`` so the deviation stays measured and
+    visible.
     """
     ad, fd, abs_err = comparison["ad"], comparison["fd"], comparison["abs_err"]
     tol = atol + rtol * np.maximum(np.abs(ad), np.abs(fd))


### PR DESCRIPTION
## Summary
- identify parameter 9 as `galaxies.lens.mass.einstein_radius` in the `RectangularKernelAdaptDensity (os_pix=1, bandwidth=0.1)` gradient check
- confirm JAX 0.9.2 and 0.10.2 return the same autodiff value, ruling out a JAX 0.10.2 autodiff regression
- document the JAX 0.10.2 finite-difference branch flip and exclude only that named comparison while retaining its printed measurement and every other gradient, liveness, and FoM assertion

## Scripts Changed
- `scripts/jax_grad/imaging_pixelization.py` — resolve the FD-unreliable parameter by name for the affected `os_pix=1` variant, document the cross-version/ULP evidence, and report the exclusion explicitly
- `scripts/jax_grad/util.py` — clarify that `skip_indices` covers documented unreliable comparisons, including finite differences that cross a discontinuity

## Corrective-PR exception
- Exact authorized Heart RED reason: `release validation FAILED (stage integrate)`
- Authorization record: https://github.com/PyAutoLabs/autolens_workspace_test/issues/164#issuecomment-4968314436
- Causal mapping: Heart reason → release-integration `jax_grad` failure → issue #164 plan → this two-script, parameter-specific diff
- Remaining sibling RED reason, not addressed here: `PyAutoFit: 1 commit(s) behind origin`
- This exception permits this one pending-release PR only. Merge, issue close, release, and release rehearsal remain forbidden while Heart is RED.

## Test Plan
- [x] Run `scripts/jax_grad/imaging_pixelization.py` end-to-end with JAX/JAXLIB 0.10.2 (pass; documented parameter-9 FD exclusion exercised)
- [x] Run the same imaging script end-to-end with isolated JAX/JAXLIB 0.9.2 (pass; autodiff value matches 0.10.2)
- [x] Run sibling `scripts/jax_grad/interferometer.py` with JAX/JAXLIB 0.10.2 (pass)
- [x] Run all six workspace smoke sets (52 passed, 0 failed, 3 declared skips)
- [x] Compile both changed scripts and run `git diff --check`
- [x] Independent review verdict: CLEAN

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: supervised (header: supervised, cap: bug → supervised)
- Plan: on issue #164, written at start and unchanged in scope
- Gate: tests n/a (workspace has no unit-test directory; exact regression scripts passed) · smoke 52 passed / 0 failed / 3 declared skips · review CLEAN · Heart RED with human-authorized corrective exception for `release validation FAILED (stage integrate)`
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

Generated by the PyAutoLabs agent workflow.
