### PR TITLE
fix(release-profile): jax_grad JAX-enable + no_run slow multi/delaunay_mge

### DIFF
--- a/config/build/env_vars_release.yaml
+++ b/config/build/env_vars_release.yaml
@@ -52,6 +52,13 @@ overrides:
   # needs JAX enabled; full-res is already the default.
   - pattern: "jax_substructure/"
     set: { PYAUTO_DISABLE_JAX: "0" }
+  # jax_grad scripts compute autodiff gradients (jax.value_and_grad) and assert
+  # finite, non-zero gradients — JAX MUST be enabled, or use_jax=False makes the
+  # likelihood numpy and the gradient of a non-traced function is all-zeros
+  # (AssertionError: Gradient is all zeros). autogalaxy_workspace_test already
+  # has this override; it was missing here (release-validation PyAutoHeart#72).
+  - pattern: "jax_grad/"
+    set: { PYAUTO_DISABLE_JAX: "0" }
   # Database scrape scripts need real search output on disk with JAX enabled;
   # PYAUTO_TEST_MODE/SMALL_DATASETS/FAST_PLOTS already match this profile's
   # defaults, only PYAUTO_DISABLE_JAX needs flipping.

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -32,3 +32,4 @@
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile
 - jax_grad/imaging_mge # NEEDS_FIX 2026-04-10 - AssertionError: Gradient is all zeros in MGE gradient computation
+- jax_likelihood_functions/multi/delaunay_mge # SLOW 2026-07-14 - real-search JAX Delaunay-MGE multi-band likelihood exceeds the 1800s mode=release cap; speedup tracked by the Profiling Agent (PyAutoHeart#72). Not a bug.


### PR DESCRIPTION
Part of the release-validation tail close-out (PyAutoHeart#72). Fixes the jax_grad 'Gradient is all zeros' config gap (missing jax_grad/ DISABLE_JAX=0 override) and SLOW-skips the too-slow multi/delaunay_mge. See #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDCsgNCXacXqiWAPTswWCt