### PR TITLE
chore(release-profile): seed advisory.yaml (mode=release advisory tier)

### DIFF
--- a/config/build/advisory.yaml
+++ b/config/build/advisory.yaml
@@ -1,0 +1,31 @@
+# Advisory-tier scripts for mode=release validation.
+#
+# These are known-slow REAL-SEARCH scripts (real Nautilus fits + finite-difference
+# JAX gradients) that flake around the per-script timeout cap under CI load. Unlike
+# no_run.yaml, an ADVISORY entry does NOT skip the script — it STILL RUNS and is
+# reported — but a *timeout* on it is advisory (YELLOW), not a release-blocking RED.
+# A timeout on any script NOT listed here is still RED. Only timeouts are de-gated;
+# a genuine exception on an advisory script is still a failure.
+#
+# This is what lets mode=release gate on correctness instead of the perf-flake tail.
+# Growing this list never erodes coverage (the script keeps running), so it converges
+# where no_run SLOW-skips whack-a-mole. Durable speedups that let entries be removed
+# are the Profiling Agent's job. See PyAutoHeart docs/release_validation.md and #74.
+#
+# Format mirrors no_run.yaml: entries with '/' substring-match the file path
+# (include '.py' to anchor); marker `# ADVISORY <YYYY-MM-DD> - <reason>`.
+#
+# Seeded from the 2026-07-13 re-val #3/#4 flip-flop population (the set literally
+# shifted run to run — shared_preloads flip-flopped). Scripts already SLOW/NEEDS_FIX
+# in no_run.yaml (imaging jax_grad/delaunay_mge/mge_group, multi/delaunay_mge,
+# database/scrape/slam_*) are NOT repeated here — no_run skips them before they run.
+
+- jax_likelihood_functions/multi/shared_preloads.py # ADVISORY 2026-07-14 - real-search JAX multi-band shared-preloads likelihood; the literal re-val #3↔#4 flip-flopper (PyAutoHeart#74)
+- jax_likelihood_functions/datacube/delaunay.py # ADVISORY 2026-07-14 - real-search JAX datacube Delaunay likelihood; near-cap flake re-val #4 (PyAutoHeart#74)
+- jax_likelihood_functions/datacube/shared_preloads.py # ADVISORY 2026-07-14 - real-search JAX datacube shared-preloads likelihood; near-cap flake (PyAutoHeart#74)
+- jax_likelihood_functions/interferometer/mge.py # ADVISORY 2026-07-14 - real-search JAX interferometer MGE likelihood; near-cap flake re-val #4 (PyAutoHeart#74)
+- jax_likelihood_functions/interferometer/mge_group.py # ADVISORY 2026-07-14 - real-search JAX interferometer MGE-group likelihood; near-cap flake (PyAutoHeart#74)
+- jax_likelihood_functions/interferometer/delaunay.py # ADVISORY 2026-07-14 - real-search JAX interferometer Delaunay likelihood; near-cap flake re-val #4 (PyAutoHeart#74)
+- jax_likelihood_functions/interferometer/delaunay_mge.py # ADVISORY 2026-07-14 - real-search JAX interferometer Delaunay-MGE likelihood; near-cap flake (PyAutoHeart#74)
+- jax_likelihood_functions/interferometer/rectangular_mge.py # ADVISORY 2026-07-14 - real-search JAX interferometer rectangular-MGE likelihood; near-cap flake (PyAutoHeart#74)
+- jax_grad/interferometer.py # ADVISORY 2026-07-14 - finite-difference JAX interferometer gradient; near-cap flake re-val #3 (PyAutoHeart#74)


### PR DESCRIPTION
## Summary

Seed `config/build/advisory.yaml` — the workspace half of the PyAutoHeart `mode=release` **advisory tier** (PyAutoHeart#74).

Declares the known-slow **real-search** scripts (real Nautilus fits + finite-difference JAX gradients) that flake around the per-script timeout cap — the 2026-07-13 re-val #3/#4 flip-flop population. With the tier (PyAutoBuild#153 / PyAutoHeart#75), a **timeout** on a declared script still runs+reports but is advisory (YELLOW), **not** release-blocking; a timeout on any **undeclared** script is still RED. Unlike a `no_run` SLOW-skip, these scripts keep running, so coverage is preserved and the list converges.

**Inert until PyAutoBuild#153 merges** (the `run_python.py` advisory loader). Library-first: this waits behind Build#153 + Heart#75.

## Test Plan
- [x] Every advisory pattern `.py`-anchored and verified to match exactly one real script.
- [ ] After PyAutoBuild#153 merges: a `mode=release` run records these as `timeout_advisory` (not `timeout`) if they exceed the cap.

Generated by the PyAutoLabs agent workflow.