### PR TITLE
run_smoke: delegate env resolution to autobuild/env_config (step 2)

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -6,25 +6,39 @@ for per-script env var overrides, then runs each listed script with the
 appropriate environment. Continues through failures and exits non-zero
 if any script failed.
 
+The env resolution itself is NOT implemented here: it is PyAutoBuild's
+`autobuild/env_config.py`, imported below. This file used to carry a copy, and
+the copy had already drifted (its `load_env_config` hardcoded
+`config/build/env_vars.yaml`, so the PR gate was structurally unable to read
+the release profile — the seed incident's failure mode 4/7). One resolver
+means the PR gate and the release runner cannot disagree about what a script's
+environment is. See PyAutoBuild docs/env_profile_redesign.md §5 (#161 step 2).
+
 Mirrors the logic of the `/smoke-test` skill so CI and local runs stay
 in sync.
 """
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import time
 from pathlib import Path
-
-import yaml
 
 
 WORKSPACE = Path(__file__).resolve().parents[2]
 SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
 ENV_VARS_FILE = WORKSPACE / "config" / "build" / "env_vars.yaml"
 SCRIPTS_DIR = WORKSPACE / "scripts"
+
+# CI puts PyAutoBuild/autobuild on PYTHONPATH (PyAutoHeart's reusable
+# smoke-tests.yml clones it alongside the dependency chain); for local runs,
+# fall back to the sibling checkout.
+try:
+    from env_config import build_env_for_script, load_env_config
+except ImportError:  # pragma: no cover - local-run fallback
+    sys.path.insert(0, str(WORKSPACE.parent / "PyAutoBuild" / "autobuild"))
+    from env_config import build_env_for_script, load_env_config
 
 
 def load_smoke_scripts() -> list[str]:
@@ -37,33 +51,20 @@ def load_smoke_scripts() -> list[str]:
     return scripts
 
 
-def load_env_config() -> dict:
+def load_cfg() -> dict | None:
+    """Parsed env profile, or None when the workspace has none.
+
+    None flows through build_env_for_script -> None -> subprocess inherits the
+    parent environment, which is what the old local copy's empty-config path
+    did by hand.
+    """
     if not ENV_VARS_FILE.exists():
-        return {"defaults": {}, "overrides": []}
-    return yaml.safe_load(ENV_VARS_FILE.read_text()) or {}
+        return None
+    return load_env_config(ENV_VARS_FILE)
 
 
-def pattern_matches(pattern: str, script_path: str) -> bool:
-    if "/" in pattern:
-        return pattern in script_path
-    return Path(script_path).stem == pattern
-
-
-def build_env(script_rel: str, cfg: dict) -> dict:
-    env = os.environ.copy()
-    defaults = cfg.get("defaults") or {}
-    env.update({k: str(v) for k, v in defaults.items()})
-    for override in cfg.get("overrides") or []:
-        if pattern_matches(override["pattern"], script_rel):
-            for key in override.get("unset", []):
-                env.pop(key, None)
-            for key, val in (override.get("set") or {}).items():
-                env[key] = str(val)
-    return env
-
-
-def run_one(script_rel: str, cfg: dict) -> tuple[str, int, float, str]:
-    env = build_env(script_rel, cfg)
+def run_one(script_rel: str, cfg: dict | None) -> tuple[str, int, float, str]:
+    env = build_env_for_script(Path(script_rel), cfg)
     script_path = SCRIPTS_DIR / script_rel
     t0 = time.time()
     result = subprocess.run(
@@ -86,7 +87,7 @@ def main() -> int:
     if not scripts:
         print("No smoke test scripts listed.")
         return 0
-    cfg = load_env_config()
+    cfg = load_cfg()
 
     print(f"Running {len(scripts)} smoke test script(s) from {SMOKE_FILE.name}\n")
     failures: list[tuple[str, int, str]] = []


### PR DESCRIPTION
## Summary

Migration **step 2** of `PyAutoBuild/docs/env_profile_redesign.md` (PyAutoBuild#161; campaign #155 Phase 3): **one resolver**. `run_smoke.py` no longer carries its own copy of the env-resolution logic — it imports PyAutoBuild's `autobuild/env_config.py`, the same resolver the release runner uses.

Why it matters: the fork had already drifted. Its `load_env_config()` took no arguments and hardcoded `config/build/env_vars.yaml`, which is *failure mode 4 made structural* — the PR gate was incapable of ever reading the release profile, so a release-profile error could only surface in the next nightly. The `build_env` cores were still line-identical, i.e. this is a fork caught mid-divergence, which is exactly when it is cheap to kill.

No infrastructure was needed: PyAutoHeart's reusable `smoke-tests.yml` **already clones PyAutoBuild and puts `PyAutoBuild/autobuild` on `PYTHONPATH`** (lines 54/90). A sibling-checkout fallback keeps the documented local invocation (`python .github/scripts/run_smoke.py`, AGENTS.md) working with no `PYTHONPATH` — verified.

Note on the hardcode: `ENV_VARS_FILE` remains as an explicit *argument* to the canonical loader — the smoke runner legitimately runs the smoke profile. What died is the resolver's inability to be pointed at any other profile; reading BOTH profiles at PR time is `validate_env_profiles`' job (step 1, merged in PyAutoBuild#163).

## API Changes

None — CI/runner internals. `load_env_config()` → `load_cfg()` locally; resolution now delegated.

## Test Plan

- [x] **Resolve-diff gate (the doc's §8 requirement), measured:** every smoke script in all three repos resolved **both ways** — old fork (loaded verbatim from `git show HEAD:`) vs new delegation — against the **real** workspaces, not a synthetic model. **61/61 scripts → byte-identical environments, 0 mismatches** (autofit 11, autogalaxy 34, autolens 16).
- [x] Local invocation without `PYTHONPATH` imports via the fallback and parses the profile.
- [x] No importers of the deleted functions anywhere (only `python run_smoke.py` invocations).
- [x] This PR's own CI **is** the smoke gate — unlike `release.yml`, this path is exercised pre-merge.

Generated by the PyAutoLabs agent workflow.
