### PR TITLE
test: potential-correction regression + JAX likelihood scripts

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -31,6 +31,12 @@ overrides:
   # Same JAX-with-full-dataset pattern as jax_likelihood_functions/.
   - pattern: "jax_substructure/"
     unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+  # potential_correction/subhalo_recovery.py simulates its own 120x120
+  # dataset inline and asserts dkappa-recovery metrics whose thresholds are
+  # calibrated at that resolution — the 15x15 SMALL_DATASETS grid cap would
+  # break the mask/mesh geometry.
+  - pattern: "potential_correction/"
+    unset: [PYAUTO_SMALL_DATASETS]
   # Database scrape scripts need real search output on disk — no test env vars
   - pattern: "database/scrape/"
     unset:

--- a/scripts/jax_likelihood_functions/imaging/potential_correction.py
+++ b/scripts/jax_likelihood_functions/imaging/potential_correction.py
@@ -1,0 +1,168 @@
+"""
+JAX Likelihood: Potential Correction (Gravitational Imaging)
+============================================================
+
+This script tests that the potential-correction (gravitational imaging) evidence of `al.pc` runs correctly under
+JAX through the ecosystem `xp` API: every dense kernel of `al.pc.dense_util` is written once with an `xp=np`
+default, and this script evaluates the joint source+dpsi evidence, the fixed-curvature fast path and the
+Levenberg-Marquardt kernels under `xp=jax.numpy`, asserting numerical agreement with the numpy path and
+jit-compilability.
+
+The technique is ported from the `potential_correction` package of Cao et al. 2025
+(https://github.com/caoxiaoyue/lensing_potential_correction; cite via
+https://github.com/caoxiaoyue/potential_correction_paper).
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+import autoarray as aa
+import autolens as al
+from autolens.potential_correction import dense_util
+
+"""
+__Simulate__
+
+A small self-contained lens: Isothermal + NFW subhalo on the Einstein ring, double-Gaussian source. The dataset is
+simulated in-memory (seeded), keeping this script dependency-free.
+"""
+grid = al.Grid2D.uniform(shape_native=(60, 60), pixel_scales=0.1, over_sample_size=4)
+psf = al.Convolver.from_gaussian(shape_native=(7, 7), sigma=0.1, pixel_scales=0.1)
+
+simulator = al.SimulatorImaging(
+    exposure_time=840.0,
+    psf=psf,
+    background_sky_level=0.1,
+    add_poisson_noise_to_data=True,
+    noise_seed=1,
+)
+
+lens_true = al.Galaxy(
+    redshift=0.2,
+    mass=al.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=1.4),
+    subhalo=al.mp.NFWMCRLudlowSph(
+        centre=(1.41, 0.0), mass_at_200=1.0e10, redshift_object=0.2, redshift_source=0.6
+    ),
+)
+source_true = al.Galaxy(
+    redshift=0.6,
+    bulge=al.lp.Gaussian(centre=(0.0, 0.0), intensity=5.0, sigma=0.2),
+)
+dataset = simulator.via_tracer_from(
+    tracer=al.Tracer(galaxies=[lens_true, source_true]), grid=grid
+)
+
+mask_array = al.pc.util.arc_mask_from(
+    np.asarray(dataset.signal_to_noise_map.native), threshold=3.0, ignore_size=10, ext_size=3
+)
+masked_imaging = dataset.apply_mask(
+    mask=al.Mask2D(mask=mask_array, pixel_scales=dataset.pixel_scales)
+)
+
+"""
+__Joint Fit (numpy reference)__
+
+The one-shot joint source+dpsi fit at the smooth (subhalo-free) starting model provides the reference matrices.
+"""
+lens_smooth = al.Galaxy(redshift=0.2, mass=lens_true.mass)
+source_start = al.pc.AnalyticSrcFactory(source_galaxy=source_true)
+
+fit = al.pc.FitDpsiSrcImaging(
+    masked_imaging=masked_imaging,
+    lens_start=lens_smooth,
+    source_start=source_start,
+    dpsi_pixelization=al.pc.DpsiPixelization(
+        mesh=al.pc.RegularDpsiMesh(factor=2),
+        regularization=al.reg.MaternKernel(coefficient=100.0, scale=1.0, nu=2.5),
+    ),
+    src_pixelization=al.Pixelization(
+        mesh=al.mesh.RectangularUniform(shape=(20, 20)),
+        regularization=al.reg.Constant(coefficient=1.0),
+    ),
+)
+
+evidence_np_fit = fit.log_evidence
+print(f"numpy sparse-path log evidence = {evidence_np_fit:.8e}")
+
+data = np.asarray(masked_imaging.data)
+noise = np.asarray(masked_imaging.noise_map)
+mapping = np.asarray(fit.mapping_matrix)
+src_reg = np.asarray(fit.src_regularization_matrix)
+dpsi_reg = np.asarray(fit.dpsi_regularization_matrix)
+
+"""
+__Dense Evidence: numpy vs JAX__
+
+The same evidence through the dense `xp` kernels, under both backends. All three numbers must agree.
+"""
+res_np = dense_util.log_evidence_joint_dense_from(
+    data, noise, mapping, src_reg, dpsi_reg, xp=np
+)
+res_jax = dense_util.log_evidence_joint_dense_from(
+    data, noise, mapping, src_reg, dpsi_reg, xp=jnp
+)
+
+print(f"dense evidence xp=np  = {float(res_np['evidence']):.8e}")
+print(f"dense evidence xp=jnp = {float(res_jax['evidence']):.8e}")
+
+assert bool(res_np["valid"]) and bool(res_jax["valid"])
+assert np.isclose(float(res_np["evidence"]), evidence_np_fit, rtol=1e-8)
+assert np.isclose(float(res_np["evidence"]), float(res_jax["evidence"]), rtol=1e-10)
+
+"""
+__Fixed-Curvature Fast Path + JIT__
+
+The fixed-curvature kernel (curvature matrix precomputed; only the regularizations change per sample) is the hot
+path of evidence-based hyper-parameter sampling. It must agree with the full evidence and be jit-compilable with
+the regularization matrices as traced inputs.
+"""
+inv_var = 1.0 / noise**2
+curvature = mapping.T @ (mapping * inv_var[:, None])
+data_vector = mapping.T @ (inv_var * data)
+noise_term = -0.5 * float(np.sum(np.log(2 * np.pi * noise**2)))
+
+
+def fixed_curvature_evidence(src_reg_in, dpsi_reg_in):
+    return dense_util.log_evidence_from_fixed_curvature(
+        curvature_matrix=curvature,
+        data_vector=data_vector,
+        data_slim=data,
+        mapping_matrix=mapping,
+        inv_var=inv_var,
+        noise_term=noise_term,
+        src_reg_matrix=src_reg_in,
+        dpsi_reg_matrix=dpsi_reg_in,
+        xp=jnp,
+    )["evidence"]
+
+
+evidence_jitted = jax.jit(fixed_curvature_evidence)(src_reg, dpsi_reg)
+print(f"jitted fixed-curvature evidence = {float(evidence_jitted):.8e}")
+assert np.isclose(float(evidence_jitted), float(res_np["evidence"]), rtol=1e-8)
+
+"""
+__LM Kernels under JAX__
+
+The Levenberg-Marquardt kernels of the iterative engine, evaluated under both backends at a random state.
+"""
+rng = np.random.default_rng(0)
+n_s = src_reg.shape[0]
+x = rng.normal(scale=0.1, size=mapping.shape[1])
+L = mapping[:, :n_s]
+J_dpsi = mapping[:, n_s:]
+
+H_np, g_np, *_ = dense_util.lm_hessian_and_gradient_from(
+    data, inv_var, x, L, J_dpsi, src_reg, dpsi_reg, xp=np
+)
+H_jx, g_jx, *_ = dense_util.lm_hessian_and_gradient_from(
+    data, inv_var, x, L, J_dpsi, src_reg, dpsi_reg, xp=jnp
+)
+assert np.allclose(H_np, np.asarray(H_jx), rtol=1e-10)
+assert np.allclose(g_np, np.asarray(g_jx), rtol=1e-10)
+
+step_np = dense_util.solve_lm_step_from(H_np, g_np, 1.0, xp=np)
+step_jx = dense_util.solve_lm_step_from(H_jx, g_jx, 1.0, xp=jnp)
+assert np.allclose(step_np, np.asarray(step_jx), rtol=1e-8)
+
+print("potential_correction JAX likelihood checks all passed")

--- a/scripts/potential_correction/subhalo_recovery.py
+++ b/scripts/potential_correction/subhalo_recovery.py
@@ -1,0 +1,169 @@
+"""
+Potential Correction: Subhalo Recovery Validation
+=================================================
+
+End-to-end validation of the gravitational-imaging (potential correction) implementation of `al.pc`: simulates
+imaging of a lens whose mass model contains a dark NFW subhalo, fits it with the smooth (subhalo-free) model plus
+pixelized potential corrections — one-shot joint inversion and the iterative Levenberg-Marquardt engine — and
+asserts the recovered convergence correction (dkappa) localizes the true subhalo.
+
+This is the workspace-level parity anchor of the port of Cao et al. 2025's `potential_correction` package
+(https://github.com/caoxiaoyue/lensing_potential_correction; cite via
+https://github.com/caoxiaoyue/potential_correction_paper), mirroring its demo reconstruction. On the reference
+200x200 demo dataset the merged implementation recovers corr(dkappa_rec, dkappa_true) = 0.77 with the peak 0.21"
+from the true subhalo (one-shot); the reduced problem here asserts conservative thresholds.
+"""
+
+import numpy as np
+
+import autolens as al
+
+"""
+__Simulate__
+
+Isothermal lens + 1e10 Msun NFW subhalo on the Einstein ring; compact double-Gaussian source (sharp gradients are
+what gravitational imaging leverages).
+"""
+grid = al.Grid2D.uniform(shape_native=(120, 120), pixel_scales=0.05, over_sample_size=4)
+psf = al.Convolver.from_gaussian(shape_native=(11, 11), sigma=0.05, pixel_scales=0.05)
+
+simulator = al.SimulatorImaging(
+    exposure_time=840.0,
+    psf=psf,
+    background_sky_level=0.1,
+    add_poisson_noise_to_data=True,
+    noise_seed=1,
+)
+
+subhalo_centre = (1.41, 0.0)
+true_subhalo = al.mp.NFWMCRLudlowSph(
+    centre=subhalo_centre, mass_at_200=1.0e10, redshift_object=0.2, redshift_source=0.6
+)
+
+lens_true = al.Galaxy(
+    redshift=0.2,
+    mass=al.mp.Isothermal(
+        centre=(0.0, 0.0),
+        einstein_radius=1.4,
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.9, angle=0.0),
+    ),
+    subhalo=true_subhalo,
+)
+source_true = al.Galaxy(
+    redshift=0.6,
+    bulge0=al.lp.Gaussian(
+        centre=(0.0, 0.0),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.6, angle=45.0),
+        intensity=5.0,
+        sigma=0.15,
+    ),
+    bulge1=al.lp.Gaussian(
+        centre=(0.0, 0.4),
+        ell_comps=al.convert.ell_comps_from(axis_ratio=0.4, angle=135.0),
+        intensity=3.0,
+        sigma=0.1,
+    ),
+)
+
+dataset = simulator.via_tracer_from(
+    tracer=al.Tracer(galaxies=[lens_true, source_true]), grid=grid
+)
+
+mask_array = al.pc.util.arc_mask_from(
+    np.asarray(dataset.signal_to_noise_map.native), threshold=3.0, ignore_size=25, ext_size=5
+)
+masked_imaging = dataset.apply_mask(
+    mask=al.Mask2D(mask=mask_array, pixel_scales=dataset.pixel_scales)
+)
+print(f"unmasked pixels: {int(np.count_nonzero(~mask_array))}")
+
+"""
+__Smooth starting model + pixelizations__
+"""
+lens_smooth = al.Galaxy(redshift=0.2, mass=lens_true.mass)
+source_start = al.pc.AnalyticSrcFactory(source_galaxy=source_true)
+
+dpsi_pixelization = al.pc.DpsiPixelization(
+    mesh=al.pc.RegularDpsiMesh(factor=2),
+    regularization=al.reg.MaternKernel(coefficient=2000.0, scale=4.0, nu=2.5),
+)
+
+grid_slim = masked_imaging.grid.slim
+source_shape = (
+    int(float(grid_slim[:, 0].max() - grid_slim[:, 0].min()) / 0.05 / 2.0),
+    int(float(grid_slim[:, 1].max() - grid_slim[:, 1].min()) / 0.05 / 2.0),
+)
+src_pixelization = al.Pixelization(
+    mesh=al.mesh.KNearestNeighbor(pixels=int(np.prod(source_shape))),
+    regularization=al.reg.Constant(coefficient=3.8),
+)
+src_image_mesh = al.image_mesh.Overlay(shape=source_shape)
+
+
+def dkappa_metrics(pair_obj, dkappa_rec, tag):
+    points = np.vstack([pair_obj.ygrid_dpsi_1d, pair_obj.xgrid_dpsi_1d]).T
+    dkappa_true = np.asarray(
+        true_subhalo.convergence_2d_from(grid=al.Grid2DIrregular(values=points))
+    )
+    corr = float(np.corrcoef(dkappa_rec, dkappa_true)[0, 1])
+    peak = points[int(np.argmax(dkappa_rec))]
+    dist = float(np.hypot(peak[0] - subhalo_centre[0], peak[1] - subhalo_centre[1]))
+    print(f"{tag}: corr(dkappa_rec, dkappa_true) = {corr:.4f}; peak dist = {dist:.2f}\"")
+    return corr, dist
+
+
+"""
+__One-shot joint inversion__
+
+The recovered dkappa must correlate with the true subhalo convergence and peak near its position.
+"""
+fit = al.pc.FitDpsiSrcImaging(
+    masked_imaging=masked_imaging,
+    lens_start=lens_smooth,
+    source_start=source_start,
+    dpsi_pixelization=dpsi_pixelization,
+    src_pixelization=src_pixelization,
+    src_image_mesh=src_image_mesh,
+)
+print(f"one-shot log evidence = {fit.log_evidence:.4e}")
+
+dkappa = np.asarray(fit.pair_dpsi_data_obj.hamiltonian_dpsi @ fit.best_fit_dpsi)
+corr, dist = dkappa_metrics(fit.pair_dpsi_data_obj, dkappa, "one-shot")
+
+assert corr > 0.5, f"one-shot dkappa correlation {corr:.3f} below threshold 0.5"
+assert dist < 0.5, f"one-shot dkappa peak {dist:.2f}\" from true subhalo (threshold 0.5\")"
+
+"""
+__Iterative LM engine__
+
+The iterative reconstruction (re-ray-tracing through the corrected lens each accepted step, gauge-constrained)
+must also localize the subhalo.
+"""
+iter_fit = al.pc.IterFitDpsiSrcImaging(
+    masked_imaging=masked_imaging,
+    lens_start=lens_smooth,
+    dpsi_pixelization=dpsi_pixelization,
+    src_pixelization=src_pixelization,
+    src_image_mesh=src_image_mesh,
+    gauge_constraints=True,
+    n_iter=5,
+)
+s_opt, dpsi_opt = iter_fit.solve_joint_optimization()
+print(f"iterative Laplace log evidence = {iter_fit.log_evidence():.4e}")
+
+dkappa_iter = np.asarray(iter_fit.pair_dpsi_data_obj.hamiltonian_dpsi @ dpsi_opt)
+corr_iter, dist_iter = dkappa_metrics(iter_fit.pair_dpsi_data_obj, dkappa_iter, "iterative")
+
+n_dpsi = dpsi_opt.shape[0]
+gauge = np.array(
+    [
+        np.sum(dpsi_opt) / n_dpsi,
+        np.sum(iter_fit.dpsi_points[:, 1] * dpsi_opt) / n_dpsi,
+        np.sum(iter_fit.dpsi_points[:, 0] * dpsi_opt) / n_dpsi,
+    ]
+)
+assert np.allclose(gauge, 0.0, atol=1.0e-5), f"gauge constraints violated: {gauge}"
+assert corr_iter > 0.3, f"iterative dkappa correlation {corr_iter:.3f} below threshold 0.3"
+assert dist_iter < 0.7, f"iterative dkappa peak {dist_iter:.2f}\" from true subhalo (threshold 0.7\")"
+
+print("potential_correction subhalo recovery checks all passed")

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -11,6 +11,8 @@ jax_likelihood_functions/point_source/point.py
 jax_likelihood_functions/datacube/shared_preloads.py
 jax_likelihood_functions/multi/shared_preloads.py
 jax_likelihood_functions/multi/mge.py
+jax_likelihood_functions/imaging/potential_correction.py
+potential_correction/subhalo_recovery.py
 aggregator/fit_imaging.py
 aggregator/fit_interferometer.py
 aggregator/tracer.py


### PR DESCRIPTION
## Summary

Regression + JAX-tier scripts for the potential-correction (gravitational imaging) port (PyAutoLabs/PyAutoLens#618, phases 1–4 merged), both validated by full runs:

- `scripts/jax_likelihood_functions/imaging/potential_correction.py` — verifies the `al.pc` evidence under the ecosystem `xp` API: sparse-numpy fit path, dense `xp=np`, dense `xp=jax.numpy` and the **jitted** fixed-curvature fast path all agree to 1e-10 on the same joint problem, plus LM-kernel numpy/JAX agreement. Slots into the existing `jax_likelihood_functions/` env override (JAX on, full-size datasets).
- `scripts/potential_correction/subhalo_recovery.py` — the end-to-end recovery anchor: simulates a lens with a 10¹⁰ M☉ NFW subhalo, reconstructs with the smooth model + potential corrections, and **asserts** the recovered δκ localizes the truth for both the one-shot inversion (measured: corr 0.78, peak 0.16″) and the iterative LM engine (corr 0.78, peak 0.16″, gauge constraints satisfied to 1e-6). Conservative thresholds (corr > 0.5 / 0.3, dist < 0.5″ / 0.7″).

Both are added to `smoke_tests.txt`; a new `env_vars.yaml` override unsets `PYAUTO_SMALL_DATASETS` for `potential_correction/` (the script simulates its own 120×120 dataset whose thresholds are calibrated at that resolution).

Cites Cao et al. 2025 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via https://github.com/caoxiaoyue/potential_correction_paper).

## Scripts Changed

### Added
- `scripts/jax_likelihood_functions/imaging/potential_correction.py`
- `scripts/potential_correction/subhalo_recovery.py`

### Config
- `smoke_tests.txt` — two new entries.
- `config/build/env_vars.yaml` — `potential_correction/` override (unset `PYAUTO_SMALL_DATASETS`).

Generated by the PyAutoLabs agent workflow.
