### PR TITLE
smoke profile: own PYAUTO_SKIP_WORKSPACE_VERSION_CHECK (step 3)

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -16,6 +16,7 @@ defaults:
   PYAUTO_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
   PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
+  PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"  # profile-owned so the base-env scrub (#161 step 3) cannot drop the mega-run's CI injection
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib


### PR DESCRIPTION
## Summary

Paired with **PyAutoBuild#161 step 3** (base-env scrub). Adds `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"` to this workspace's **smoke** profile (`config/build/env_vars.yaml`).

Why: the mega-run (`PyAutoHeart workspace-validation.yml`) injects that var at the job `env:` level, and the smoke profile was silent on it. Once PyAutoBuild's resolver scrubs the ambient `PYAUTO_*` family, an ambient-only injection would be dropped and every mega-run smoke script would fail `WorkspaceVersionMismatchError`. Making the profile own the var keeps the mega-run byte-identical (proven: 65/65 scripts unchanged) while closing the ambient-leak surface.

The release profile already sets this var; this brings the smoke profile in line.

## Test Plan

- [x] This PR's own smoke gate (clones PyAutoBuild at the matching `feature/env-scrubbed-baseline` branch, so it runs against the scrub) is the end-to-end check.

Generated by the PyAutoLabs agent workflow.
