### PR TITLE
Warm-start the imaging potential-correction iterative test

### DIFF
--- a/scripts/potential_correction/subhalo_recovery.py
+++ b/scripts/potential_correction/subhalo_recovery.py
@@ -137,7 +137,18 @@ assert dist < 0.5, f"one-shot dkappa peak {dist:.2f}\" from true subhalo (thresh
 __Iterative LM engine__
 
 The iterative reconstruction (re-ray-tracing through the corrected lens each accepted step, gauge-constrained)
-must also localize the subhalo.
+must also localize the subhalo. It is warm-started from the one-shot joint solution `[s | dpsi]` — the certified
+recipe (PyAutoLens#630, mirroring the interferometer uv campaign #627): under the Marquardt-scale LM damping
+`mu * diag(H)`, cold-starting from zeros no longer reliably lands in the subhalo basin, but refining inside the
+one-shot basin does. The LM then confirms the one-shot correction is a genuine cost minimum rather than drifting
+off it.
+
+Each accepted LM step re-imposes the gauge constraints <dpsi,1> = <dpsi,x> = <dpsi,y> = 0 on the updated state,
+but from the (un-gauged) one-shot solution the gauge-fixing move slides along the model-degenerate constant /
+deflection-drift modes and is not cost-decreasing, so it is rejected and the solve would stall off the constraint
+surface. Passing `gauge_project_x0=True` has the engine project those modes out of x0 first; they are the null
+space of the Hamiltonian dpsi -> dkappa map, so the recovered convergence correction (and every assertion below)
+is unchanged while the gauge-constrained solve stays on the constraint surface.
 """
 iter_fit = al.pc.IterFitDpsiSrcImaging(
     masked_imaging=masked_imaging,
@@ -148,7 +159,8 @@ iter_fit = al.pc.IterFitDpsiSrcImaging(
     gauge_constraints=True,
     n_iter=5,
 )
-s_opt, dpsi_opt = iter_fit.solve_joint_optimization()
+x0 = np.concatenate([np.asarray(fit.best_fit_source), np.asarray(fit.best_fit_dpsi)])
+s_opt, dpsi_opt = iter_fit.solve_joint_optimization(x0=x0, gauge_project_x0=True)
 print(f"iterative Laplace log evidence = {iter_fit.log_evidence():.4e}")
 
 dkappa_iter = np.asarray(iter_fit.pair_dpsi_data_obj.hamiltonian_dpsi @ dpsi_opt)


### PR DESCRIPTION
## Why

`potential_correction/subhalo_recovery.py` cold-started the iterative LM engine (`x0=zeros`), which recovered the subhalo (`corr 0.78`) until PyAutoLens `ad97e5fd5` switched LM damping to `mu*diag(H)` (for the interferometer). Under scale-invariant damping, cold-start from zeros no longer lands in the subhalo basin and the iterative dkappa correlation collapsed to a deterministic **`0.032`** — failing CI on `main` (3.12 & 3.13), env-independent (reproduced with the full smoke env *and* bare). The one-shot inversion was unaffected (`0.78`). Bisected to `ad97e5fd5`: the port test was green until the next `iterative.py` change landed.

## What

Switch to the certified warm-start recipe (PyAutoLens#630): `x0 =` the one-shot joint solution `[s | dpsi]`, with **`gauge_project_x0=True`** so the engine projects the un-gauged one-shot dpsi onto the gauge surface before iterating. The LM now refines inside the one-shot basin — `corr 0.7822`, evidence `9.07e3` (up from cold's `4.21e3`) — and the gauge constraints hold. This is the first test to exercise the `x0` warm-start feature.

Verified end-to-end under the smoke env (`TEST_MODE=2`, `DISABLE_JAX=1`): all assertions pass.

## Dependency

Requires the matching-name **PyAutoLens#632** (adds `gauge_project_x0`); the smoke CI clones that branch automatically. **Merge the library PR first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3MxfFWYP7cBPyLGE8MWAV