### PR TITLE
Rename PyAutoBuild to PyAutoHands

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -6,13 +6,13 @@ for per-script env var overrides, then runs each listed script with the
 appropriate environment. Continues through failures and exits non-zero
 if any script failed.
 
-The env resolution itself is NOT implemented here: it is PyAutoBuild's
+The env resolution itself is NOT implemented here: it is PyAutoHands's
 `autobuild/env_config.py`, imported below. This file used to carry a copy, and
 the copy had already drifted (its `load_env_config` hardcoded
 `config/build/env_vars.yaml`, so the PR gate was structurally unable to read
 the release profile — the seed incident's failure mode 4/7). One resolver
 means the PR gate and the release runner cannot disagree about what a script's
-environment is. See PyAutoBuild docs/env_profile_redesign.md §5 (#161 step 2).
+environment is. See PyAutoHands docs/env_profile_redesign.md §5 (#161 step 2).
 
 Mirrors the logic of the `/smoke-test` skill so CI and local runs stay
 in sync.
@@ -31,13 +31,13 @@ SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
 ENV_VARS_FILE = WORKSPACE / "config" / "build" / "env_vars.yaml"
 SCRIPTS_DIR = WORKSPACE / "scripts"
 
-# CI puts PyAutoBuild/autobuild on PYTHONPATH (PyAutoHeart's reusable
+# CI puts PyAutoHands/autobuild on PYTHONPATH (PyAutoHeart's reusable
 # smoke-tests.yml clones it alongside the dependency chain); for local runs,
 # fall back to the sibling checkout.
 try:
     from env_config import build_env_for_script, load_env_config
 except ImportError:  # pragma: no cover - local-run fallback
-    sys.path.insert(0, str(WORKSPACE.parent / "PyAutoBuild" / "autobuild"))
+    sys.path.insert(0, str(WORKSPACE.parent / "PyAutoHands" / "autobuild"))
     from env_config import build_env_for_script, load_env_config
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ write from a header skim silently deletes every section below the header.
 
 - Source libs: `../PyAutoLens`, `../PyAutoGalaxy`, `../PyAutoArray`, `../PyAutoFit`, `../PyAutoConf`.
 - `../autolens_workspace` — the user-facing workspace; `../HowToLens` — the tutorial series.
-- `../PyAutoBuild` — CI / build tooling.
+- `../PyAutoHands` — CI / build tooling.
 - `../autolens_assistant` — science-assistant workspace (literature wiki).
 
 ## Task Workflows

--- a/config/build/copy_files.yaml
+++ b/config/build/copy_files.yaml
@@ -1,11 +1,11 @@
 # Files copied as-is into notebooks/ instead of being converted from
-# scripts/. Used by PyAutoBuild's generate.py during the pre-build step.
+# scripts/. Used by PyAutoHands's generate.py during the pre-build step.
 #
 # Format: flat list of script paths relative to the workspace root.
 # Patterns matched by suffix — any file path ending with one of these
 # entries is treated as copy-only.
 #
-# This file overrides PyAutoBuild/autobuild/config/copy_files.yaml for
+# This file overrides PyAutoHands/autobuild/config/copy_files.yaml for
 # this workspace. Add or remove entries here, not there.
 
 []

--- a/config/build/visualise_notebooks.yaml
+++ b/config/build/visualise_notebooks.yaml
@@ -1,10 +1,10 @@
-# Notebook stems that should run when PyAutoBuild's generate / run pipeline
+# Notebook stems that should run when PyAutoHands's generate / run pipeline
 # is invoked with --visualise. Used to refresh notebook output cells in main.
 #
 # Format: flat list of notebook stems (no extension, no path).
 # An empty list means no notebooks need re-visualisation in this workspace.
 #
-# This file overrides PyAutoBuild/autobuild/config/visualise_notebooks.yaml
+# This file overrides PyAutoHands/autobuild/config/visualise_notebooks.yaml
 # for this workspace. Add or remove entries here, not there.
 
 []


### PR DESCRIPTION
Part of the coordinated **PyAutoBuild → PyAutoHands** repository rename (the Hands organ). Updates `run_smoke.py`'s PYTHONPATH fallback (`../PyAutoHands/autobuild`) + docstring, config-comment paths, and the Related-Repos bullet.

**Preserved (backwards-compatible):** the `autobuild` package name (only the sibling-dir prefix changed).

**Merge order:** the renamed repo (PyAutoLabs/PyAutoHands#167) should land first.

See `PyAutoHands/MIGRATION.md` for the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsYpZBw74w5g1kAqpWEAiE)_