### PR TITLE
refactor: import config surface from autolens instead of autoconf

### DIFF
--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -9,8 +9,8 @@ import os
 import shutil
 from os import path
 
-from autoconf import conf
-from autoconf.conf import with_config
+from autolens import conf
+from autolens import with_config
 import autofit as af
 import autolens as al
 from autolens import fixtures

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -9,8 +9,8 @@ import os
 import shutil
 from os import path
 
-from autoconf import conf
-from autoconf.conf import with_config
+from autolens import conf
+from autolens import with_config
 import autofit as af
 import autolens as al
 from autolens import fixtures

--- a/scripts/aggregator/tracer.py
+++ b/scripts/aggregator/tracer.py
@@ -9,8 +9,8 @@ import os
 import shutil
 from os import path
 
-from autoconf import conf
-from autoconf.conf import with_config
+from autolens import conf
+from autolens import with_config
 import autofit as af
 import autolens as al
 from autolens import fixtures

--- a/scripts/cluster/csv_api.py
+++ b/scripts/cluster/csv_api.py
@@ -19,7 +19,7 @@ Outputs are written to ``dataset/cluster/test/``. The next script in the chain â
 â€” loads these CSVs and runs the lensing simulation to produce ``data.fits`` + ``point_datasets.csv``.
 """
 
-from autoconf import jax_wrapper  # Sets JAX environment before other imports
+from autolens import jax_wrapper  # Sets JAX environment before other imports
 
 from pathlib import Path
 

--- a/scripts/cluster/likelihood_sanity.py
+++ b/scripts/cluster/likelihood_sanity.py
@@ -37,7 +37,7 @@ Run from the ``autolens_workspace_test`` repo root::
         python scripts/cluster/likelihood_sanity.py
 """
 
-from autoconf import jax_wrapper  # Sets JAX environment before other imports
+from autolens import jax_wrapper  # Sets JAX environment before other imports
 
 import copy
 import subprocess

--- a/scripts/cluster/simulator.py
+++ b/scripts/cluster/simulator.py
@@ -16,7 +16,7 @@ The truth model is read entirely from CSVs; no parameter values are duplicated i
 Re-running it after editing the CSVs produces a new dataset reflecting whatever you edited.
 """
 
-from autoconf import jax_wrapper  # Sets JAX environment before other imports
+from autolens import jax_wrapper  # Sets JAX environment before other imports
 
 import jax
 import jax.numpy as jnp

--- a/scripts/imaging/modeling_visualization_jit.py
+++ b/scripts/imaging/modeling_visualization_jit.py
@@ -38,7 +38,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from autoconf.test_mode import with_test_mode_segment
+from autolens import with_test_mode_segment
 
 import autofit as af
 import autolens as al

--- a/scripts/imaging/modeling_visualization_jit_delaunay.py
+++ b/scripts/imaging/modeling_visualization_jit_delaunay.py
@@ -35,7 +35,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from autoconf.test_mode import with_test_mode_segment
+from autolens import with_test_mode_segment
 
 import autofit as af
 import autolens as al

--- a/scripts/imaging/modeling_visualization_jit_rectangular.py
+++ b/scripts/imaging/modeling_visualization_jit_rectangular.py
@@ -34,7 +34,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from autoconf.test_mode import with_test_mode_segment
+from autolens import with_test_mode_segment
 
 import autofit as af
 import autolens as al

--- a/scripts/imaging/simulator_use_jax_parity.py
+++ b/scripts/imaging/simulator_use_jax_parity.py
@@ -19,7 +19,7 @@ rebuilds native ``Array2D`` wrappers with NumPy indexing, which is not a valid
 JIT boundary for traced image values.
 """
 
-from autoconf import jax_wrapper  # Sets JAX float64 before other imports
+from autolens import jax_wrapper  # Sets JAX float64 before other imports
 
 import numpy as np
 

--- a/scripts/imaging/visualization.py
+++ b/scripts/imaging/visualization.py
@@ -41,7 +41,7 @@ from types import SimpleNamespace
 
 # Push the bespoke all-true plots.yaml before any visualization method reads config.
 # This must come before autolens imports trigger config reads in visualization code paths.
-from autoconf import conf
+from autolens import conf
 
 conf.instance.push(
     new_path=path.join(path.dirname(path.realpath(__file__)), "config"),

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -29,7 +29,7 @@ from os import path
 from pathlib import Path
 from types import SimpleNamespace
 
-from autoconf import conf
+from autolens import conf
 
 conf.instance.push(
     new_path=path.join(path.dirname(path.realpath(__file__)), "config_source"),

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -38,7 +38,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from autoconf.test_mode import with_test_mode_segment
+from autolens import with_test_mode_segment
 
 import autofit as af
 import autolens as al

--- a/scripts/interferometer/simulator_use_jax_parity.py
+++ b/scripts/interferometer/simulator_use_jax_parity.py
@@ -14,7 +14,7 @@ deterministic Fourier-transform path.
 Also tests the @jax.jit roundtrip for the interferometer simulator.
 """
 
-from autoconf import jax_wrapper  # Sets JAX float64 before other imports
+from autolens import jax_wrapper  # Sets JAX float64 before other imports
 
 import jax
 import numpy as np

--- a/scripts/interferometer/visualization.py
+++ b/scripts/interferometer/visualization.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 # Push the bespoke all-true plots.yaml before any visualization method reads config.
-from autoconf import conf
+from autolens import conf
 
 conf.instance.push(
     new_path=path.join(path.dirname(path.realpath(__file__)), "config"),

--- a/scripts/jax_likelihood_functions/datacube/delaunay.py
+++ b/scripts/jax_likelihood_functions/datacube/delaunay.py
@@ -35,7 +35,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 n_channels = 4
 

--- a/scripts/jax_likelihood_functions/datacube/rectangular.py
+++ b/scripts/jax_likelihood_functions/datacube/rectangular.py
@@ -36,7 +36,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 n_channels = 4
 

--- a/scripts/jax_likelihood_functions/imaging/delaunay.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 sub_size = 4

--- a/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 sub_size = 4
 psf_shape_2d = (21, 21)

--- a/scripts/jax_likelihood_functions/imaging/lp.py
+++ b/scripts/jax_likelihood_functions/imaging/lp.py
@@ -38,7 +38,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Dataset__

--- a/scripts/jax_likelihood_functions/imaging/mge.py
+++ b/scripts/jax_likelihood_functions/imaging/mge.py
@@ -38,7 +38,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 """

--- a/scripts/jax_likelihood_functions/imaging/mge_group.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group.py
@@ -38,7 +38,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 """

--- a/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 sub_size = 4

--- a/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 sub_size = 4
 psf_shape_2d = (21, 21)

--- a/scripts/jax_likelihood_functions/interferometer/delaunay.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay.py
@@ -16,7 +16,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
@@ -17,7 +17,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/lp.py
+++ b/scripts/jax_likelihood_functions/interferometer/lp.py
@@ -17,7 +17,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 """

--- a/scripts/jax_likelihood_functions/interferometer/rectangular.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular.py
@@ -37,7 +37,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
@@ -20,7 +20,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
@@ -17,7 +17,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
@@ -21,7 +21,7 @@ from os import path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 """
 __Mask__

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -38,7 +38,7 @@ from pathlib import Path
 
 import autofit as af
 import autolens as al
-from autoconf import conf
+from autolens import conf
 
 
 """

--- a/scripts/multi/visualization_imaging.py
+++ b/scripts/multi/visualization_imaging.py
@@ -38,7 +38,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 # Push the imaging test's all-true plots.yaml so subplot_fit lands on disk.
-from autoconf import conf
+from autolens import conf
 
 conf.instance.push(
     new_path=path.join(

--- a/scripts/multi/visualization_interferometer.py
+++ b/scripts/multi/visualization_interferometer.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 # Push the interferometer test's all-true plots.yaml so subplot_fit lands on disk.
-from autoconf import conf
+from autolens import conf
 
 conf.instance.push(
     new_path=path.join(

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 
-from autoconf.test_mode import with_test_mode_segment
+from autolens import with_test_mode_segment
 
 import autofit as af
 import autolens as al

--- a/scripts/profiling/aggregator/mock_lens_results.py
+++ b/scripts/profiling/aggregator/mock_lens_results.py
@@ -28,7 +28,7 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
-from autoconf import conf
+from autolens import conf
 import autofit as af
 import autolens as al
 from autolens import fixtures


### PR DESCRIPTION
## What

Rewrite `from autoconf[.sub] import X` → `from autolens import X` across the integration-test scripts, so they import the config/serialization surface through the science library rather than depending on `autoconf` directly.

## Notes

- The Colab bootstrap `from autoconf import setup_colab` (where present) is intentionally left on `autoconf`.
- Pairs with the `autolens` re-export PR on the same-named branch; the smoke job checks out that branch.

## Validation

CI running on this branch (push-triggered) — please confirm Smoke Tests before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_