### PR TITLE
fix(build): full-data env_vars overrides + park pixelization gradient bug

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -68,6 +68,12 @@ overrides:
     unset: [PYAUTO_SMALL_DATASETS]
   - pattern: "jax_grad/imaging_mge"
     unset: [PYAUTO_SMALL_DATASETS]
+  # jax_grad/imaging_pixelization spawns jax_likelihood_functions/imaging/simulator.py
+  # as a subprocess; under PYAUTO_SMALL_DATASETS=1 the simulator builds a slim 256 (16x16)
+  # array against a 441 (21x21) mask -> ArrayException. subprocess.run inherits os.environ,
+  # so unsetting the cap for the parent propagates to the simulator.
+  - pattern: "jax_grad/imaging_pixelization"
+    unset: [PYAUTO_SMALL_DATASETS]
   # Model composition scripts assert prior_count for full-size MGE bases.
   # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
   - pattern: "model_composition/"
@@ -102,6 +108,13 @@ overrides:
   # The script does not run a non-linear search, so it is only useful at
   # full resolution; just unset the cap.
   - pattern: "multi/visualization_imaging"
+    unset: [PYAUTO_SMALL_DATASETS]
+  # multi/dataset_model_parity_delaunay asserts the two-frame Delaunay parity
+  # (profile-baked vs DatasetModel) agrees within a ~0.2 log_likelihood pixel-
+  # sampling floor. PYAUTO_SMALL_DATASETS=1 caps the grid to 16x16, where that
+  # floor is meaningless (the frames disagree by ~90). CONFIRMED it agrees at
+  # full size (A0=-1144.359, A1=-1144.384); the parity test is only useful there.
+  - pattern: "multi/dataset_model_parity_delaunay"
     unset: [PYAUTO_SMALL_DATASETS]
   # point_source/visualization.py asserts fit.png lands on disk and uses a
   # JSON point dataset (no FITS, no mask) — PYAUTO_FAST_PLOTS must be unset

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -32,6 +32,7 @@
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile
 - jax_grad/imaging_mge # NEEDS_FIX 2026-04-10 - AssertionError: Gradient is all zeros in MGE gradient computation
+- jax_grad/imaging_pixelization # NEEDS_FIX 2026-07-21 - AssertionError: Gradient is all zeros in pixelization gradient computation (same family as imaging_mge above; likely needs custom_jvp). The env_vars.yaml PYAUTO_SMALL_DATASETS override was added so it runs at full data — previously it fault-masked as a 256-vs-441 ArrayException — but the underlying zero-gradient bug remains; remove this marker once fixed.
 - jax_likelihood_functions/multi/delaunay_mge # SLOW 2026-07-14 - real-search JAX Delaunay-MGE multi-band likelihood exceeds the 1800s mode=release cap; speedup tracked by the Profiling Agent (PyAutoHeart#72). Not a bug.
 # Real-search JAX likelihood/gradient scripts that flake around the mode=release
 # per-script timeout cap (the re-val #3/#4 flip-flop population). SLOW-skipped to


### PR DESCRIPTION
Closes part of PyAutoLabs/autolens_workspace_test#185 (Tier 1 build-honesty from the 2026-07-20 full local build sweep).

Two scripts failed in the faithful build **only** under the smoke profile's `PYAUTO_SMALL_DATASETS=1` cap — both verified env-config gaps, not code bugs.

## Scripts Changed
_Config-only — no `scripts/` or `notebooks/` changed._
- `config/build/env_vars.yaml` — two new `unset: [PYAUTO_SMALL_DATASETS]` overrides:
  - `multi/dataset_model_parity_delaunay` — 16² breaks the Delaunay parity floor; confirmed agrees at full size (A0=-1144.359, A1=-1144.384).
  - `jax_grad/imaging_pixelization` — subprocess simulator built a slim 256 (16²) array vs a 441 (21²) mask.
- `config/build/no_run.yaml` — new NEEDS_FIX marker for `jax_grad/imaging_pixelization`. Its override cleared the `SMALL_DATASETS` fault-mask and revealed a **genuine "Gradient is all zeros" bug** (same family as parked `jax_grad/imaging_mge`; likely needs `custom_jvp`). Honestly parked; the override stays so it runs at full data once fixed.

## Verification
`run_python.py` in a worktree against the installed stack: `dataset_model_parity_delaunay` PASS, siblings PASS, no regressions.

Heart RED at ship time; opened under the corrective-PR exception scoped to the RED reason `workspace validation not passing (10 failed, 2026-07-20T15-09-29Z)`. Merge deferred to human.