### PR TITLE
fix(jax_grad): un-break gradient build scripts (env_vars PYAUTO_DISABLE_JAX)

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -64,16 +64,20 @@ overrides:
   # must be unset.
   - pattern: "imaging/visualization_jax"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  - pattern: "jax_grad/imaging_lp"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "jax_grad/imaging_mge"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # jax_grad/imaging_pixelization spawns jax_likelihood_functions/imaging/simulator.py
-  # as a subprocess; under PYAUTO_SMALL_DATASETS=1 the simulator builds a slim 256 (16x16)
-  # array against a 441 (21x21) mask -> ArrayException. subprocess.run inherits os.environ,
-  # so unsetting the cap for the parent propagates to the simulator.
-  - pattern: "jax_grad/imaging_pixelization"
-    unset: [PYAUTO_SMALL_DATASETS]
+  # jax_grad/ scripts drive jax.value_and_grad + finite-difference gradient
+  # correctness checks. They need JAX enabled — PYAUTO_DISABLE_JAX=1 forces the
+  # numpy xp path while autodiff traces the likelihood, so the traced input is
+  # never differentiated: imaging_lp (positions path) raises
+  # TracerArrayConversionError; imaging_mge / imaging_pixelization return an
+  # all-zero gradient. They also need full-resolution float64 data for the FD
+  # comparison. (imaging_pixelization additionally spawns
+  # jax_likelihood_functions/imaging/simulator.py as a subprocess; under
+  # PYAUTO_SMALL_DATASETS=1 the simulator builds a slim 256 (16x16) array
+  # against a 441 (21x21) mask -> ArrayException. subprocess.run inherits
+  # os.environ, so unsetting the cap for the parent propagates to the
+  # simulator.) Same pattern as jax_likelihood_functions/.
+  - pattern: "jax_grad/"
+    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
   # Model composition scripts assert prior_count for full-size MGE bases.
   # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
   - pattern: "model_composition/"

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -30,9 +30,6 @@
 - point_source/modeling_visualization_jit # SLOW 2026-07-08 - JIT + Part-2 live Nautilus fit exceeds 300s cap; same family as imaging/interferometer modeling_visualization_jit (the zero_contour perf-assert false-positive was separately fixed to a cold/warm ratio, which now lets the script run past it into the slow fit)
 - jax_likelihood_functions/imaging/delaunay_mge # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
-- jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile
-- jax_grad/imaging_mge # NEEDS_FIX 2026-04-10 - AssertionError: Gradient is all zeros in MGE gradient computation
-- jax_grad/imaging_pixelization # NEEDS_FIX 2026-07-21 - AssertionError: Gradient is all zeros in pixelization gradient computation (same family as imaging_mge above; likely needs custom_jvp). The env_vars.yaml PYAUTO_SMALL_DATASETS override was added so it runs at full data — previously it fault-masked as a 256-vs-441 ArrayException — but the underlying zero-gradient bug remains; remove this marker once fixed.
 - jax_likelihood_functions/multi/delaunay_mge # SLOW 2026-07-14 - real-search JAX Delaunay-MGE multi-band likelihood exceeds the 1800s mode=release cap; speedup tracked by the Profiling Agent (PyAutoHeart#72). Not a bug.
 # Real-search JAX likelihood/gradient scripts that flake around the mode=release
 # per-script timeout cap (the re-val #3/#4 flip-flop population). SLOW-skipped to


### PR DESCRIPTION
Closes #188.

## Summary

The `jax_grad/*` gradient-correctness scripts were flagged as raising or returning all-zero gradients (`NEEDS_FIX`), assumed to be the "needs `custom_jvp`" lineage. **Reproduction on clean `main` overturned that premise** — the gradient math already passes. The real failure is a config bug: `config/build/env_vars.yaml` defaults set `PYAUTO_DISABLE_JAX: "1"`, and the `jax_grad/imaging_{lp,mge,pixelization}` overrides unset `PYAUTO_SMALL_DATASETS` but forgot `PYAUTO_DISABLE_JAX` (unlike `jax_likelihood_functions/`). With JAX force-disabled the library takes the numpy `xp` path while `jax.value_and_grad` traces the likelihood, so the traced input is never differentiated:

- `imaging_lp` (has a positions path) → `jax.errors.TracerArrayConversionError`
- `imaging_mge` / `imaging_pixelization` (no positions path) → **all-zero gradient**

One cause, all three original symptoms. No `custom_jvp` / library work is needed.

## Changes

- **`config/build/env_vars.yaml`** — replace the three per-script `jax_grad/imaging_{lp,mge,pixelization}` overrides with one folder-level `jax_grad/` override that unsets **both** `PYAUTO_SMALL_DATASETS` and `PYAUTO_DISABLE_JAX` (mirrors the `jax_likelihood_functions/` precedent). This also correctly wires `point_source` and `weak`, which were un-overridden and silently broken in the sweep under `DISABLE_JAX=1`.
- **`config/build/no_run.yaml`** — remove the three stale `NEEDS_FIX` markers (`imaging_lp`/`imaging_mge` 2026-04-10, `imaging_pixelization` 2026-07-21). `jax_grad/interferometer.py` (SLOW) left intact.

## Scripts Changed

None — no `.py` scripts were edited. This is a build-config-only change (`config/build/env_vars.yaml`, `config/build/no_run.yaml`). The affected scripts (`jax_grad/imaging_lp`, `imaging_mge`, `imaging_pixelization`, `point_source`, `weak`) already pass; this change lets the build run them with JAX enabled at full data.

## Validation (clean `main`, CPU fp64)

- **Fixed env** (JAX enabled, full data): `imaging_lp`, `imaging_mge`, `imaging_pixelization` (all 7 variants), `point_source`, `weak` — all pass, autodiff = finite differences.
- **Build-default env** (`PYAUTO_DISABLE_JAX=1`): `imaging_lp` raises `TracerArrayConversionError`; `imaging_pixelization` fails at variant A with `AssertionError: Gradient is all zeros` — reproducing the original markers.

## Notes

Opened under the corrective-PR exception for the Heart RED reason `58 stale parked script(s)` (this PR removes 3 of them). All other RED reasons are pre-existing and unrelated to this change. Merge stays a human decision.