### PR TITLE
fix(test): un-park imaging/visualization + wire cluster/visualization (viz asserts)

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -129,3 +129,11 @@ overrides:
   # point_source/modeling_visualization_jit — live Nautilus + JIT path.
   - pattern: "point_source/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
+  # cluster/visualization.py asserts 5 subplot PNGs land on disk
+  # (PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray) and
+  # loads its data.fits at full resolution while asserting per-plane tangential
+  # critical-curve recovery on a full-extent 250x250 viz_grid — the 15x15
+  # SMALL_DATASETS cap would break the mask geometry. Both must be unset.
+  # (Also no_run-listed as SLOW: the curve computation is ~580s > 300s cap.)
+  - pattern: "cluster/visualization.py"
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -22,12 +22,12 @@
 - database/scrape/slam_general # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - database/scrape/slam_pix # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
-- imaging/visualization # NEEDS_FIX 2026-04-10 - AssertionError: dataset.png missing after visualization refactor
 - imaging/modeling_visualization_jit # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap (autogalaxy variant ~90s); unblocked by PR #70 from prior `expected jax.Array, got numpy.float64` AssertionError, now hits perf wall
 - imaging/modeling_visualization_jit_delaunay # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap; same root cause as modeling_visualization_jit
 - imaging/modeling_visualization_jit_rectangular # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 301s cap; same root cause as modeling_visualization_jit
 - interferometer/modeling_visualization_jit # SLOW 2026-05-20 - JIT + full visualization pipeline exceeds 300s cap; same root cause as imaging/modeling_visualization_jit family
 - point_source/modeling_visualization_jit # SLOW 2026-07-08 - JIT + Part-2 live Nautilus fit exceeds 300s cap; same family as imaging/interferometer modeling_visualization_jit (the zero_contour perf-assert false-positive was separately fixed to a cold/warm ratio, which now lets the script run past it into the slow fit)
+- cluster/visualization # SLOW 2026-07-21 - per-plane critical-curve + caustic computation on the required full-extent 250x250 viz_grid (multi-plane marching squares) totals ~580s, over the 300s cap; same perf family as the modeling_visualization_jit scripts. Curves DO recover (plane-1 7 CC, plane-2 1 CC at full data) and the per-plane physics assertion passes — this is NOT the mislabelled "#1280 zero_contour algorithmic regression", which does not reproduce. env_vars.yaml unsets FAST_PLOTS/SMALL_DATASETS so it runs green in manual/full runs.
 - jax_likelihood_functions/imaging/delaunay_mge # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_likelihood_functions/imaging/mge_group # NEEDS_FIX 2026-04-10 - timeout in JAX likelihood function benchmark
 - jax_grad/imaging_lp # NEEDS_FIX 2026-04-10 - JAX traceback in gradient computation for light profile

--- a/scripts/imaging/modeling_visualization_jit.py
+++ b/scripts/imaging/modeling_visualization_jit.py
@@ -207,8 +207,8 @@ sanity_od = LensCalc.from_tracer(sanity_tracer)
 # Correctness — tangential critical curves exist and Einstein radius is finite.
 tc_list = sanity_od.tangential_critical_curve_list_via_zero_contour_from()
 assert len(tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 er_sanity = sanity_od.einstein_radius_via_zero_contour_from()
 assert np.isfinite(float(er_sanity)) and float(er_sanity) > 0.0, (

--- a/scripts/imaging/modeling_visualization_jit_delaunay.py
+++ b/scripts/imaging/modeling_visualization_jit_delaunay.py
@@ -284,8 +284,8 @@ _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
 _tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/imaging/modeling_visualization_jit_rectangular.py
+++ b/scripts/imaging/modeling_visualization_jit_rectangular.py
@@ -270,8 +270,8 @@ _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
 _tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -166,8 +166,8 @@ _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
 _tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -189,8 +189,8 @@ _sanity_od = _SanityLensCalc.from_tracer(_sanity_tracer)
 
 _tc_list = _sanity_od.tangential_critical_curve_list_via_zero_contour_from()
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -163,8 +163,8 @@ _tc_list = (
 )  # cold: first call on fresh instance (JIT compile)
 _sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -168,8 +168,8 @@ _tc_list = (
 )  # cold: first call on fresh instance (JIT compile)
 _sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (

--- a/scripts/point_source/visualization_jax.py
+++ b/scripts/point_source/visualization_jax.py
@@ -157,8 +157,8 @@ _tc_list = (
 )  # cold: first call on fresh instance (JIT compile)
 _sanity_cold_dt = _sanity_time.perf_counter() - _sanity_t0
 assert len(_tc_list) > 0, (
-    "no tangential critical curves returned by zero_contour — algorithmic "
-    "regression (PyAutoGalaxy abd7b717 / PyAutoFit #1280 family)"
+    "no tangential critical curves returned by zero_contour — expected a "
+    "non-empty tangential critical curve for this lens at this grid resolution"
 )
 _er_sanity = _sanity_od.einstein_radius_via_zero_contour_from()
 assert _sanity_np.isfinite(float(_er_sanity)) and float(_er_sanity) > 0.0, (


### PR DESCRIPTION
## Summary
The workspace-test sweep surfaced two visualization assert failures. Investigation found neither was a code bug:

- **`imaging/visualization` "dataset.png missing"** — caused by `PYAUTO_FAST_PLOTS=1` short-circuiting `subplot_save()`; the env-override fix already landed on main (`0768310`). The script passes; only its stale `no_run.yaml` NEEDS_FIX marker remained.
- **`#1280` tangential-critical-curve family** — not an algorithmic regression. Curves recover everywhere (pure geometry small+full grid; `visualization_jax`; cluster multi-plane full data: 7 CC plane-1, 1 CC plane-2). The only real blocker was `cluster/visualization.py`, which was wired into neither config: it failed on the same FAST_PLOTS PNG gap, and its required 250×250 grid runs ~580s > 300s cap.

PyAutoFit#1280 is a merged revert PR, not an open blocker. No library change needed — workspace-only.

Fixes PyAutoLabs/autolens_workspace_test#187.

## Scripts Changed
- `config/build/no_run.yaml` — removed stale `imaging/visualization` NEEDS_FIX (now green); added `cluster/visualization` SLOW (~580s > 300s cap, same family as `modeling_visualization_jit`)
- `config/build/env_vars.yaml` — added `cluster/visualization.py` override unsetting `PYAUTO_FAST_PLOTS` + `PYAUTO_SMALL_DATASETS`
- `scripts/{imaging,interferometer,point_source}/{visualization_jax,modeling_visualization_jit*}.py` (8 files) — refreshed the stale "#1280 family / abd7b717 algorithmic regression" assert message into a self-contained diagnostic

## Test Plan
- [x] `imaging/visualization.py` under resolved sweep env → EXIT 0
- [x] `cluster/visualization.py` full data → EXIT 0 (all PNGs + per-plane physics assert)
- [x] `critical_curves_zero_contour.py` (small+full), `imaging/visualization_jax.py` → pass
- [x] Both YAMLs parse; all 8 edited scripts compile

Generated by the PyAutoLabs agent workflow.