### PR TITLE
fix: exclude gallery_build.py from validation — build tool, not a test

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -44,3 +44,7 @@
 - jax_likelihood_functions/interferometer/delaunay_mge.py # SLOW 2026-07-14 - real-search JAX interferometer Delaunay-MGE likelihood; flakes at the 1800s cap (PyAutoHeart#74)
 - jax_likelihood_functions/interferometer/rectangular_mge.py # SLOW 2026-07-14 - real-search JAX interferometer rectangular-MGE likelihood; flakes at the 1800s cap (PyAutoHeart#74)
 - jax_grad/interferometer.py # SLOW 2026-07-14 - finite-difference JAX interferometer gradient; flakes at the 1800s cap (PyAutoHeart#74)
+
+# Permanent skips (NOT to-do markers — these scripts are correct as-is and simply
+# do not belong in the validated script set).
+- gallery/gallery_build # PERMANENT - build tool, not a test. Consumes the images produced by scripts/gallery/gallery_run.sh; validation runs it standalone, so scan_images() finds nothing and it takes its documented early exit ("No images found under scripts/*/images", gallery_build.py:159-163). Runs clean wherever the images exist.


### PR DESCRIPTION
## Summary

One of the five `workspace-validation` shard failures blocking `nightly-release` at Stage 3 (integrate). Not a bug — a build tool being run as if it were a test.

`workspace-validation` runs `scripts/gallery/gallery_build.py` standalone, without `scripts/gallery/gallery_run.sh` having produced any images first. `scan_images()` therefore returns empty and the script takes its documented early exit at `gallery_build.py:159-163`:

```
No images found under scripts/*/images — run scripts/gallery/gallery_run.sh first.
sys.exit(1)
```

which fails the shard in 0.1s.

The script is correct. Run locally where the images exist it completes cleanly across 9 domains (69 png / 20 fits). It is a gallery build tool that consumes another script's output, so it does not belong in the validated script set at all.

Added as a **permanent, untagged** entry rather than `SLOW` or `NEEDS_FIX`: both of those are to-do markers surfaced in the mega-run warning banner for work that still needs doing, and there is nothing here to fix.

Verified against `should_skip` that the pattern matches `scripts/gallery/gallery_build.py` and does not match unrelated scripts. `validate_env_profiles` is unchanged at 0 errors / 30 warnings — the 30 are pre-existing JAX-marker drift, identical on `main`.

## Scripts Changed

No scripts changed — configuration only.

- `config/build/no_run.yaml` — permanent skip for `gallery/gallery_build`, with the reason inline

Refs PyAutoLabs/autolens_workspace#314