### PR TITLE
fix: cap smoke scripts at BUILD_SCRIPT_TIMEOUT and kill the process group

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -6,6 +6,11 @@ for per-script env var overrides, then runs each listed script with the
 appropriate environment. Continues through failures and exits non-zero
 if any script failed.
 
+Each script is capped at `BUILD_SCRIPT_TIMEOUT` seconds (default 300), the same
+env var and default PyAutoHands's `build_util.py` uses, so the PR gate and the
+release runner agree about how long a script may take. On expiry the script's
+whole process group is killed and the entry is reported as TIMEOUT.
+
 The env resolution itself is NOT implemented here: it is PyAutoHands's
 `autobuild/env_config.py`, imported below. This file used to carry a copy, and
 the copy had already drifted (its `load_env_config` hardcoded
@@ -20,11 +25,19 @@ in sync.
 
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
 
+
+# Per-script wall-clock cap, shared with PyAutoHands's build_util.py so the PR
+# gate and the release runner agree about how long a script may take. Same env
+# var, same 300s default; workspace-validation raises it to 1800 for
+# mode=release.
+TIMEOUT_SECS = int(os.environ.get("BUILD_SCRIPT_TIMEOUT", "300"))
 
 WORKSPACE = Path(__file__).resolve().parents[2]
 SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
@@ -64,19 +77,56 @@ def load_cfg() -> dict | None:
 
 
 def run_one(script_rel: str, cfg: dict | None) -> tuple[str, int, float, str]:
+    """Run one smoke script, capped at TIMEOUT_SECS.
+
+    The script runs in its own session (``start_new_session=True``) so that a
+    timeout can kill the whole process group rather than just the direct child.
+    That distinction is load-bearing: capturing output means waiting for the
+    stdout pipe to reach EOF, and any grandchild that inherited the pipe holds
+    it open even after the child itself has exited. A script whose work has
+    finished can therefore hang the runner indefinitely, which is exactly how
+    smoke CI came to sit at the 6-hour GitHub Actions ceiling (issue #196) while
+    reporting nothing since the last completed script. Killing the group closes
+    the inherited pipe and lets the read finish.
+    """
     env = build_env_for_script(Path(script_rel), cfg)
     script_path = SCRIPTS_DIR / script_rel
     t0 = time.time()
-    result = subprocess.run(
+    proc = subprocess.Popen(
         [sys.executable, str(script_path)],
         cwd=str(WORKSPACE),
         env=env,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
+        start_new_session=True,
     )
+    timed_out = False
+    try:
+        output, _ = proc.communicate(timeout=TIMEOUT_SECS)
+        returncode = proc.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _kill_group(proc)
+        # The group is gone, so this drains whatever was buffered and returns.
+        output, _ = proc.communicate()
+        returncode = proc.returncode if proc.returncode not in (None, 0) else 124
     elapsed = time.time() - t0
-    output = result.stdout + result.stderr
-    return script_rel, result.returncode, elapsed, output
+    if timed_out:
+        output = (output or "") + (
+            f"\n::error::TIMEOUT after {TIMEOUT_SECS}s — killed the process group. "
+            f"Raise BUILD_SCRIPT_TIMEOUT if this script is legitimately slow, or "
+            f"add it to config/build/no_run.yaml with a dated SLOW marker.\n"
+        )
+    return script_rel, returncode, elapsed, output or ""
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    """SIGKILL the script's whole process group, tolerating an already-dead one."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):  # pragma: no cover - race
+        proc.kill()
 
 
 def main() -> int:
@@ -95,7 +145,12 @@ def main() -> int:
         print(f"::group::{script_rel}")
         name, rc, elapsed, output = run_one(script_rel, cfg)
         print(output, end="")
-        status = "PASS" if rc == 0 else f"FAIL (exit {rc})"
+        if rc == 0:
+            status = "PASS"
+        elif rc == 124:
+            status = f"TIMEOUT ({TIMEOUT_SECS}s)"
+        else:
+            status = f"FAIL (exit {rc})"
         print(f"\n[{status}] {name} — {elapsed:.1f}s")
         print("::endgroup::")
         if rc != 0:
@@ -105,7 +160,8 @@ def main() -> int:
     passed = total - len(failures)
     print(f"\n=== Smoke test summary: {passed}/{total} passed ===")
     for name, rc, _ in failures:
-        print(f"  FAIL  {name}  (exit {rc})")
+        label = f"TIMEOUT ({TIMEOUT_SECS}s)" if rc == 124 else f"FAIL  (exit {rc})"
+        print(f"  {label}  {name}")
     return 0 if not failures else 1
 
 

--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -110,7 +110,12 @@ def run_one(script_rel: str, cfg: dict | None) -> tuple[str, int, float, str]:
         _kill_group(proc)
         # The group is gone, so this drains whatever was buffered and returns.
         output, _ = proc.communicate()
-        returncode = proc.returncode if proc.returncode not in (None, 0) else 124
+        # Always 124 (the conventional timeout code), never the signal we just
+        # sent. Reporting proc.returncode here would surface -9 for a script
+        # killed mid-run and mislabel a timeout as an ordinary failure; the two
+        # need distinguishing because only one of them means "raise the cap or
+        # SLOW-skip it".
+        returncode = 124
     elapsed = time.time() - t0
     if timed_out:
         output = (output or "") + (

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -9,7 +9,7 @@ jax_likelihood_functions/interferometer/rectangular.py
 jax_likelihood_functions/interferometer/mge.py
 jax_likelihood_functions/point_source/point.py
 jax_likelihood_functions/datacube/shared_preloads.py
-jax_likelihood_functions/multi/shared_preloads.py
+# jax_likelihood_functions/multi/shared_preloads.py  # disabled 2026-07-22: exceeds the 300s smoke cap (measured 300s+ in CI, autolens_workspace_test#196). Already SLOW-marked in config/build/no_run.yaml for flaking at the release runner's 1800s cap (PyAutoHeart#74) — it is the heaviest entry here and does not belong in the fast PR gate. Its sibling datacube/shared_preloads.py (27.8s) keeps the shared-preloads path covered. Re-enable if it is made fast enough.
 jax_likelihood_functions/multi/mge.py
 jax_likelihood_functions/imaging/potential_correction.py
 jax_likelihood_functions/interferometer/potential_correction.py


### PR DESCRIPTION
## Summary

Fixes the runner-side half of #196: smoke CI hanging for six hours instead of failing.

`run_smoke.py` called `subprocess.run(..., capture_output=True)` with **no timeout**. Capturing output means waiting for the stdout pipe to reach EOF, and a grandchild process that inherited that pipe holds it open **even after the child itself has exited**. So a script whose work has completed can still block the runner forever.

That matches the CI signature exactly. From hung run 29917295791:

```
[PASS] jax_likelihood_functions/interferometer/mge.py — 19.6s
##[group] jax_likelihood_functions/point_source/point.py     <-- opens, never closes
...
PASS: jit(fit_from) round-trip matches NumPy scalar.        <-- 11:56:36, script's own output
                                                            <-- nothing at all for 5h55m
##[error] The operation was canceled.                        <-- 17:51:33
Terminate orphan process: pid (2811) (python)
Terminate orphan process: pid (3170) (python)
```

The script finished its work and printed its PASS line; two orphan Pythons kept the pipe open.

**Reproduced locally.** A script that prints, spawns a sleeping grandchild, and exits 0 blocks the old call indefinitely (still blocked at 25s, exit 124).

## What this changes

- Each script is capped at `BUILD_SCRIPT_TIMEOUT`, default `300` — the **exact env var and default** PyAutoHands's `build_util.py` already uses, so the PR gate and the release runner cannot disagree about how long a script may take. `workspace-validation` already raises it to `1800` for `mode=release`.
- Scripts run with `start_new_session=True`, and on expiry the **whole process group** is SIGKILLed. This is the load-bearing part: killing only the direct child would leave the grandchild holding the pipe, so the group kill is what actually unblocks the read.
- Timeouts surface as `TIMEOUT (Ns)` with exit `124` and an `::error::` annotation naming `BUILD_SCRIPT_TIMEOUT` and the `no_run.yaml` SLOW convention, instead of being flattened into a generic failure. Genuine non-zero exits keep their own exit code.

## Verification

| Case | Result |
|---|---|
| Orphan-grandchild repro (old code) | blocks indefinitely — reproduces the CI hang |
| Orphan-grandchild repro (new code) | returns at exactly the cap, `rc=124`, output + annotation captured |
| Leaked processes after timeout | **0** — group kill confirmed |
| Passing script | `rc=0`, output intact |
| Failing script (`sys.exit(3)`) | `rc=3` preserved, not masked as a timeout |

`ruff check` and `ruff format --check` clean.

## Expected effect on this PR's own CI

If `point.py` still hangs on this branch, this PR's smoke job will now **fail at 300s with `TIMEOUT`** instead of burning six hours. That is the fix working as intended — it converts a silent hang into an honest, fast failure and lets the remaining 14 smoke scripts be reached in future runs. The underlying reason `point.py` hangs is **not** addressed here and remains open in #196.

## Scope note

`run_smoke.py` is duplicated across **10 repos** in 3 variants (`*_workspace_test` ×4, user workspaces ×3, `HowTo*` ×3) and **none** of them has a timeout. This PR fixes only the copy where the hang is demonstrated. The duplication is itself the underlying problem — this file's own docstring records the same lesson about its previously-drifted `env_config` copy — so the real fix is to centralise the runner in PyAutoHands alongside `env_config.py`. Filed as follow-up in #196.

## Scripts Changed

No workspace scripts changed — CI runner only.

- `.github/scripts/run_smoke.py` — per-script timeout + process-group kill + TIMEOUT reporting

Refs #196