### PR TITLE
docs(readme): drop the orphaned library version pin (#155 Phase 4 task 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ python slam/imaging/no_lens_light/source_lp/mass_total/no_hyper.py
 
 # Workspace Version
 
-This version of the workspace are built and tested for using **PyAutoLens v2026.5.14.1**.
+These scripts track PyAutoLens `main` and the **latest PyAutoLens release** — they are run by CI
+against both, so no exact version is pinned here. A named pin in this README was owned by
+nobody after the release runner stopped bumping it, and went ~2 months stale; the user-facing
+workspaces carry the authoritative compatibility floor instead
+(`version.minimum_library_version` in their `config/general.yaml`).
 
 # Build Configuration
 


### PR DESCRIPTION
Drops the orphaned `<pkg> vX` line from this README (build-chain campaign PyAutoHands#155, Phase 4 task 4).

**Why it was orphaned:** the release runner stopped bumping the pin under PyAutoBuild#120/#121, and `pre_build`s local sed never staged its edit (deleted in #158). Nothing has owned it since — the pins were up to ~2 months stale, and after 2026.7.9.1 one of them named a *yanked* release.

**Decision (user, this session):** drop the pins rather than give the runner ownership again. Re-adding a runner-side sed+commit means a new commit-to-`main` step of the kind #120/#121 deliberately removed, to maintain a string no gate reads. The machine-checked signal is `version.minimum_library_version` in `config/general.yaml`, which Heart `version_skew` verifies against the newest release tag (all 7 floors OK on todays 2026.7.22.1).

Docs-only; no script, config, or notebook touched.