### PR TITLE
feat: derive the release JAX set from name markers (#181 step 4)

### DIFF
--- a/config/build/env_vars_release.yaml
+++ b/config/build/env_vars_release.yaml
@@ -17,70 +17,22 @@
 # real plots — makes the profile self-contained regardless of the caller's
 # environment.
 #
-# "overrides" then only ever `set:` a var to flip it away from this profile's
-# own default for specific scripts — never `unset:` a var that "defaults"
-# already pins, since unsetting just re-exposes the same inherited-env gap
-# `defaults` exists to close. In practice that leaves PYAUTO_DISABLE_JAX as
-# the only var any override here still needs to touch (PYAUTO_TEST_MODE="0"
-# and the full-res/real-plot defaults already satisfy every other unset the
-# smoke profile's env_vars.yaml needs).
-#
-# Pattern convention (same as no_run.yaml):
-#   - Patterns containing '/' do a substring match against the file path
-#     including extension (so patterns may end in `.py` to anchor against
-#     the script form, e.g. `imaging/visualization.py` matches only the
-#     `.py` script, not `imaging/visualization_jax.py`).
-#   - Patterns without '/' match the file stem exactly.
+# The JAX set is DERIVED, not enumerated (PyAutoHands
+# docs/env_profile_redesign.md §3): `derive_jax_markers: true` makes the
+# resolver run any script whose path segment/stem matches `jax_*` / `*_jax` /
+# `*_jit` with PYAUTO_DISABLE_JAX="0". Adding a JAX script to a `jax_*` folder
+# (or naming it `*_jax` / `*_jit`) self-registers — there is no override list
+# to keep in sync, and the validator errors on any PYAUTO_DISABLE_JAX override
+# creeping back in (the hand-enumerated list was the silent-rot failure mode).
 
 defaults:
   PYAUTO_TEST_MODE: "0"                     # real searches (each script caps its own n_like_max)
   PYAUTO_SMALL_DATASETS: "0"                # full-res grids/masks (release fidelity, not smoke)
-  PYAUTO_DISABLE_JAX: "1"                   # force use_jax=False by default; JAX-specific folders re-enable below
+  PYAUTO_DISABLE_JAX: "1"                   # force use_jax=False by default; the marker derivation re-enables JAX
   PYAUTO_FAST_PLOTS: "0"                    # real plots (release fidelity, not smoke)
   PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"  # TestPyPI dev version won't match the workspace pin
   JAX_ENABLE_X64: "True"                    # enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"       # writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"           # writable config dir for matplotlib
 
-overrides:
-  # JAX likelihood functions test JIT compilation — need JAX enabled (already
-  # full-res/real-plots by default above).
-  - pattern: "jax_likelihood_functions/"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  # JAX substructure scripts test the full simulate_substructure /
-  # batched_simulate_substructure path with an explicit image_shape=(51,51) —
-  # needs JAX enabled; full-res is already the default.
-  - pattern: "jax_substructure/"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  # jax_grad scripts compute autodiff gradients (jax.value_and_grad) and assert
-  # finite, non-zero gradients — JAX MUST be enabled, or use_jax=False makes the
-  # likelihood numpy and the gradient of a non-traced function is all-zeros
-  # (AssertionError: Gradient is all zeros). autogalaxy_workspace_test already
-  # has this override; it was missing here (release-validation PyAutoHeart#72).
-  - pattern: "jax_grad/"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  # Database scrape scripts need real search output on disk with JAX enabled;
-  # PYAUTO_TEST_MODE/SMALL_DATASETS/FAST_PLOTS already match this profile's
-  # defaults, only PYAUTO_DISABLE_JAX needs flipping.
-  - pattern: "database/scrape/"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  # visualization_jax scripts (imaging/interferometer/point_source) exercise
-  # the jit-cached fit_for_visualization path (registered model + autoarray
-  # pytrees) and must run with JAX enabled — PYAUTO_DISABLE_JAX="1" would
-  # silently flip use_jax flags off and the script would no-op.
-  - pattern: "imaging/visualization_jax"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  - pattern: "interferometer/visualization_jax"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  - pattern: "point_source/visualization_jax"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  # modeling_visualization_jit (imaging/interferometer/point_source) test the
-  # JIT-cached visualization path: Part 1 asserts log_likelihood is a
-  # jax.Array, so JAX must be enabled. PYAUTO_TEST_MODE="0" (real Nautilus
-  # run) and full-res/real-plots are already this profile's defaults.
-  - pattern: "imaging/modeling_visualization_jit"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  - pattern: "interferometer/modeling_visualization_jit"
-    set: { PYAUTO_DISABLE_JAX: "0" }
-  - pattern: "point_source/modeling_visualization_jit"
-    set: { PYAUTO_DISABLE_JAX: "0" }
+derive_jax_markers: true

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -18,13 +18,13 @@
 #   banner. Investigate the failure, fix the underlying bug, and remove
 #   the NEEDS_FIX marker.
 
-- database/scrape/multi_analysis # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
-- database/scrape/slam_general # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
-- database/scrape/slam_multi_one_by_one # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
-- database/scrape/slam_pix # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/multi_analysis_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_general_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_multi_one_by_one_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
+- database/scrape/slam_pix_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - imaging/modeling_visualization_jit # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap (autogalaxy variant ~90s); unblocked by PR #70 from prior `expected jax.Array, got numpy.float64` AssertionError, now hits perf wall
-- imaging/modeling_visualization_jit_delaunay # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap; same root cause as modeling_visualization_jit
-- imaging/modeling_visualization_jit_rectangular # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 301s cap; same root cause as modeling_visualization_jit
+- imaging/modeling_visualization_delaunay_jit # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 300s cap; same root cause as modeling_visualization_jit
+- imaging/modeling_visualization_rectangular_jit # SLOW 2026-05-07 - JIT + full visualization pipeline exceeds 301s cap; same root cause as modeling_visualization_jit
 - interferometer/modeling_visualization_jit # SLOW 2026-05-20 - JIT + full visualization pipeline exceeds 300s cap; same root cause as imaging/modeling_visualization_jit family
 - point_source/modeling_visualization_jit # SLOW 2026-07-08 - JIT + Part-2 live Nautilus fit exceeds 300s cap; same family as imaging/interferometer modeling_visualization_jit (the zero_contour perf-assert false-positive was separately fixed to a cold/warm ratio, which now lets the script run past it into the slow fit)
 - cluster/visualization # SLOW 2026-07-21 - per-plane critical-curve + caustic computation on the required full-extent 250x250 viz_grid (multi-plane marching squares) totals ~580s, over the 300s cap; same perf family as the modeling_visualization_jit scripts. Curves DO recover (plane-1 7 CC, plane-2 1 CC at full data) and the per-plane physics assertion passes — this is NOT the mislabelled "#1280 zero_contour algorithmic regression", which does not reproduce. env_vars.yaml unsets FAST_PLOTS/SMALL_DATASETS so it runs green in manual/full runs.

--- a/scripts/database/scrape/multi_analysis_jax.py
+++ b/scripts/database/scrape/multi_analysis_jax.py
@@ -364,7 +364,7 @@ def fit():
         dataset_list.append(dataset)
 
     settings_search = af.SettingsSearch(
-        path_prefix=path.join("database", "scrape", "multi_analysis"),
+        path_prefix=path.join("database", "scrape", "multi_analysis_jax"),
         number_of_cores=1,
         session=None,
         info={"hi": "there"},
@@ -527,7 +527,7 @@ def fit():
 
     agg = Aggregator.from_database(database_file)
     agg.add_directory(
-        directory=path.join("output", "database", "scrape", "multi_analysis")
+        directory=path.join("output", "database", "scrape", "multi_analysis_jax")
     )
 
     assert len(agg) > 0

--- a/scripts/database/scrape/slam_general_jax.py
+++ b/scripts/database/scrape/slam_general_jax.py
@@ -1,11 +1,11 @@
 """
-Database: SLaM Pixelization
-============================
+Database: SLaM General
+======================
 
-Runs a SLaM pipeline (pixelization with AdaptSplit regularization) and scrapes the results to a database,
+Runs a SLaM pipeline (linear light profiles) and scrapes the results to a database,
 verifying that queries and aggregator modules work correctly.
 
-Based on autolens_workspace/scripts/imaging/features/pixelization/slam.py
+Based on autolens_workspace/scripts/imaging/features/linear_light_profiles/slam.py
 """
 
 from astropy.io import fits
@@ -36,12 +36,7 @@ def fit():
     ):
         analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
-        lens_bulge = al.model_util.mge_model_from(
-            mask_radius=mask_radius,
-            total_gaussians=20,
-            gaussian_per_basis=2,
-            centre_prior_is_uniform=True,
-        )
+        lens_bulge = af.Model(al.lp_linear.Sersic)
 
         source_bulge = al.model_util.mge_model_from(
             mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
@@ -194,7 +189,6 @@ def fit():
     def light_lp(
         settings_search,
         dataset,
-        mask_radius,
         source_result_for_lens,
         source_result_for_source,
         n_batch=20,
@@ -208,15 +202,9 @@ def fit():
         analysis = al.AnalysisImaging(
             dataset=dataset,
             adapt_images=adapt_images,
-            use_jax=True,
         )
 
-        lens_bulge = al.model_util.mge_model_from(
-            mask_radius=mask_radius,
-            total_gaussians=20,
-            gaussian_per_basis=2,
-            centre_prior_is_uniform=True,
-        )
+        lens_bulge = af.Model(al.lp_linear.Sersic)
 
         source = al.util.chaining.source_custom_model_from(
             result=source_result_for_source, source_is_model=False
@@ -270,7 +258,6 @@ def fit():
                     factor=3.0, minimum_threshold=0.2
                 )
             ],
-            use_jax=True,
         )
 
         mass = al.util.chaining.mass_from(
@@ -342,7 +329,7 @@ def fit():
     dataset = dataset.apply_mask(mask=mask)
 
     settings_search = af.SettingsSearch(
-        path_prefix=path.join("database", "scrape", "slam_pix"),
+        path_prefix=path.join("database", "scrape", "slam_general_jax"),
         number_of_cores=1,
         session=None,
         info={"hi": "there"},
@@ -385,7 +372,6 @@ def fit():
     light_result = light_lp(
         settings_search=settings_search,
         dataset=dataset,
-        mask_radius=mask_radius,
         source_result_for_lens=source_pix_result_1,
         source_result_for_source=source_pix_result_2,
     )
@@ -405,7 +391,7 @@ def fit():
     """
     from autofit.database.aggregator import Aggregator
 
-    database_file = "database_directory_slam_pix.sqlite"
+    database_file = "database_directory_slam_general.sqlite"
 
     try:
         os.remove(path.join("output", database_file))
@@ -413,7 +399,9 @@ def fit():
         pass
 
     agg = Aggregator.from_database(database_file)
-    agg.add_directory(directory=path.join("output", "database", "scrape", "slam_pix"))
+    agg.add_directory(
+        directory=path.join("output", "database", "scrape", "slam_general_jax")
+    )
 
     assert len(agg) > 0
 

--- a/scripts/database/scrape/slam_multi_one_by_one_jax.py
+++ b/scripts/database/scrape/slam_multi_one_by_one_jax.py
@@ -401,7 +401,7 @@ def fit():
     dataset = dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
 
     settings_search = af.SettingsSearch(
-        path_prefix=path.join("database", "scrape", "slam_multi_one_by_one"),
+        path_prefix=path.join("database", "scrape", "slam_multi_one_by_one_jax"),
         number_of_cores=1,
         session=None,
         info={"hi": "there"},
@@ -556,7 +556,7 @@ def fit():
         dataset = dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
 
         settings_search_secondary = af.SettingsSearch(
-            path_prefix=path.join("database", "scrape", "slam_multi_one_by_one"),
+            path_prefix=path.join("database", "scrape", "slam_multi_one_by_one_jax"),
             unique_tag=f"{dataset_name}_data_{dataset_waveband}",
             number_of_cores=1,
             session=None,
@@ -676,7 +676,7 @@ def fit():
 
     agg = Aggregator.from_database(database_file)
     agg.add_directory(
-        directory=path.join("output", "database", "scrape", "slam_multi_one_by_one")
+        directory=path.join("output", "database", "scrape", "slam_multi_one_by_one_jax")
     )
 
     assert len(agg) > 0

--- a/scripts/database/scrape/slam_pix_jax.py
+++ b/scripts/database/scrape/slam_pix_jax.py
@@ -1,11 +1,11 @@
 """
-Database: SLaM General
-======================
+Database: SLaM Pixelization
+============================
 
-Runs a SLaM pipeline (linear light profiles) and scrapes the results to a database,
+Runs a SLaM pipeline (pixelization with AdaptSplit regularization) and scrapes the results to a database,
 verifying that queries and aggregator modules work correctly.
 
-Based on autolens_workspace/scripts/imaging/features/linear_light_profiles/slam.py
+Based on autolens_workspace/scripts/imaging/features/pixelization/slam.py
 """
 
 from astropy.io import fits
@@ -36,7 +36,12 @@ def fit():
     ):
         analysis = al.AnalysisImaging(dataset=dataset, use_jax=True)
 
-        lens_bulge = af.Model(al.lp_linear.Sersic)
+        lens_bulge = al.model_util.mge_model_from(
+            mask_radius=mask_radius,
+            total_gaussians=20,
+            gaussian_per_basis=2,
+            centre_prior_is_uniform=True,
+        )
 
         source_bulge = al.model_util.mge_model_from(
             mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=False
@@ -189,6 +194,7 @@ def fit():
     def light_lp(
         settings_search,
         dataset,
+        mask_radius,
         source_result_for_lens,
         source_result_for_source,
         n_batch=20,
@@ -202,9 +208,15 @@ def fit():
         analysis = al.AnalysisImaging(
             dataset=dataset,
             adapt_images=adapt_images,
+            use_jax=True,
         )
 
-        lens_bulge = af.Model(al.lp_linear.Sersic)
+        lens_bulge = al.model_util.mge_model_from(
+            mask_radius=mask_radius,
+            total_gaussians=20,
+            gaussian_per_basis=2,
+            centre_prior_is_uniform=True,
+        )
 
         source = al.util.chaining.source_custom_model_from(
             result=source_result_for_source, source_is_model=False
@@ -258,6 +270,7 @@ def fit():
                     factor=3.0, minimum_threshold=0.2
                 )
             ],
+            use_jax=True,
         )
 
         mass = al.util.chaining.mass_from(
@@ -329,7 +342,7 @@ def fit():
     dataset = dataset.apply_mask(mask=mask)
 
     settings_search = af.SettingsSearch(
-        path_prefix=path.join("database", "scrape", "slam_general"),
+        path_prefix=path.join("database", "scrape", "slam_pix_jax"),
         number_of_cores=1,
         session=None,
         info={"hi": "there"},
@@ -372,6 +385,7 @@ def fit():
     light_result = light_lp(
         settings_search=settings_search,
         dataset=dataset,
+        mask_radius=mask_radius,
         source_result_for_lens=source_pix_result_1,
         source_result_for_source=source_pix_result_2,
     )
@@ -391,7 +405,7 @@ def fit():
     """
     from autofit.database.aggregator import Aggregator
 
-    database_file = "database_directory_slam_general.sqlite"
+    database_file = "database_directory_slam_pix.sqlite"
 
     try:
         os.remove(path.join("output", database_file))
@@ -399,9 +413,7 @@ def fit():
         pass
 
     agg = Aggregator.from_database(database_file)
-    agg.add_directory(
-        directory=path.join("output", "database", "scrape", "slam_general")
-    )
+    agg.add_directory(directory=path.join("output", "database", "scrape", "slam_pix_jax"))
 
     assert len(agg) > 0
 

--- a/scripts/imaging/modeling_visualization_delaunay_jit.py
+++ b/scripts/imaging/modeling_visualization_delaunay_jit.py
@@ -4,7 +4,7 @@ with a DELAUNAY-pixelization source.
 ==========================================================================
 
 Sibling to ``modeling_visualization_jit.py`` (MGE) and
-``modeling_visualization_jit_rectangular.py`` (rectangular mesh). Exercises
+``modeling_visualization_rectangular_jit.py`` (rectangular mesh). Exercises
 the same Path A pipeline — ``Analysis.fit_for_visualization`` lazily-cached
 as ``jax.jit(self.fit_from)`` — but with a Delaunay-triangulated source
 whose centres are placed by a Hilbert image mesh.
@@ -331,7 +331,7 @@ analysis_live = al.AnalysisImaging(
 )
 
 output_root = (
-    Path("scripts") / "imaging" / "images" / "modeling_visualization_jit_delaunay"
+    Path("scripts") / "imaging" / "images" / "modeling_visualization_delaunay_jit"
 )
 if output_root.exists():
     shutil.rmtree(output_root)

--- a/scripts/imaging/modeling_visualization_rectangular_jit.py
+++ b/scripts/imaging/modeling_visualization_rectangular_jit.py
@@ -319,7 +319,7 @@ analysis_live = al.AnalysisImaging(
 )
 
 output_root = (
-    Path("scripts") / "imaging" / "images" / "modeling_visualization_jit_rectangular"
+    Path("scripts") / "imaging" / "images" / "modeling_visualization_rectangular_jit"
 )
 if output_root.exists():
     shutil.rmtree(output_root)


### PR DESCRIPTION
## Summary
Phase B of PyAutoHands#181 step 4 (design: PyAutoHands `docs/env_profile_redesign.md` §3): the release profile's hand-enumerated `PYAUTO_DISABLE_JAX` overrides (10 patterns) are deleted; the JAX set is now **derived by the resolver from name markers** (`derive_jax_markers: true`). Six scripts are renamed so their names honestly carry the marker. Ends the state where 11 scripts literally named for JAX (`jax_assertions/`, `hessian_jax.py`, `profiles_jit.py`, `tracer_jax.py`) ran NumPy in every nightly.

## Scripts Changed
- `config/build/env_vars_release.yaml` — deleted all 10 `PYAUTO_DISABLE_JAX` overrides; added `derive_jax_markers: true`; header rewritten for the derivation.
- `scripts/imaging/modeling_visualization_jit_delaunay.py` → `modeling_visualization_delaunay_jit.py` — a mid-stem `_jit_` is invisible to the marker rule; the suffix carries it (internal image-output paths updated).
- `scripts/imaging/modeling_visualization_jit_rectangular.py` → `modeling_visualization_rectangular_jit.py` — same.
- `scripts/database/scrape/{slam_general,slam_pix,slam_multi_one_by_one,multi_analysis}.py` → `*_jax.py` — these four pass `use_jax=True` **explicitly in code**; the rename marks them so a future un-skip gets JAX instead of a silent downgrade (all four are no_run'd SLOW; internal output-path strings updated).
- `config/build/no_run.yaml` — 6 entries follow the renames.

## Verification (resolved-env diff — binding; smoke cannot see config-only changes)
`resolve_clean()` over all 154 scripts, old profile (main) vs new (renames mapped): **exactly 14 changes, all `PYAUTO_DISABLE_JAX` only**:
- **11 turn ON** (were vacuously NumPy): `jax_assertions/` ×8 (incl. the no-op `__init__.py`), `hessian_jax.py`, `profiles_jit.py`, `tracer_jax.py`. Each of the 10 runnable scripts was run locally under its exact new JAX-on release env: all pass, 2–11 s each.
- **3 turn OFF**: `database/scrape/{__init__,general,scaling_relation}.py` — `general.py` and `scaling_relation.py` contain no JAX usage and both pass locally under the exact NumPy release env.
- The 6 renamed scripts resolve **identically** before/after.

Validator: 0 errors, 0 warnings — **including under `--strict-derivation --strict-markers`** (step 5's future gate). CI-env parity: `workspace-validation.yml` injects only `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK`, which the profile also pins itself.

## Upstream PR
https://github.com/PyAutoLabs/PyAutoHands/pull/182 — **must merge first**: the nightly runs `run_python.py` from the PyAutoHands main checkout; without #182 the `derive_jax_markers` key is inert and every previously-override-listed script would run NumPy.

## Test Plan
- [x] Resolved-env diff = exactly the triaged set (above), nothing else
- [x] 10 runnable turns-ON scripts pass under JAX locally; both runnable turns-OFF scrape scripts pass under NumPy locally
- [x] Smoke tests pass (per-PR gate profile `env_vars.yaml` untouched)
- [ ] Release surface is exercised only by the nightly mega-run — mega-run verification accepted, per plan

## Heart gate
Shipped to PR-open under human acknowledgement (2026-07-23) of pre-existing RED: `release validation FAILED (stage integrate)`; `workspace validation not passing (13 failed, 2026-07-21T19-05-22Z)`; `33 stale parked script(s)` — all predate this task. Merge is a separate human act behind the library-first gate.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
