### PR TITLE
chore: drop legacy env_vars.yaml fallback from run_smoke (#161 step 6, stage 3)

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -41,14 +41,7 @@ TIMEOUT_SECS = int(os.environ.get("BUILD_SCRIPT_TIMEOUT", "300"))
 
 WORKSPACE = Path(__file__).resolve().parents[2]
 SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
-# Prefer the canonical profile name; the legacy fallback below dies at the
-# stage-3 cleanup (PyAutoHands#161 step 6).
-_SMOKE_PROFILE = WORKSPACE / "config" / "build" / "profile_smoke.yaml"
-ENV_VARS_FILE = (
-    _SMOKE_PROFILE
-    if _SMOKE_PROFILE.exists()
-    else WORKSPACE / "config" / "build" / "env_vars.yaml"
-)
+ENV_VARS_FILE = WORKSPACE / "config" / "build" / "profile_smoke.yaml"
 SCRIPTS_DIR = WORKSPACE / "scripts"
 
 # CI puts PyAutoHands/autohands on PYTHONPATH (PyAutoHeart's reusable


### PR DESCRIPTION
## Summary
Step 6 stage 3 (PyAutoHands#181): the vendored `.github/scripts/run_smoke.py` drops its migration-window legacy fallback and reads `config/build/profile_smoke.yaml` directly. The PyAutoHands validator now errors on legacy-named files, so the old name cannot return.

## Scripts Changed
- `.github/scripts/run_smoke.py` — legacy `env_vars.yaml` fallback removed (plain canonical assignment; AST-parse verified; repo grep for the old name returns nothing)

## Test Plan
- [x] `env_vars` grep clean; runner parses
- [ ] This PR's smoke gate green (the runner exercising the canonical-only path)

## Heart gate
Continuation of today's #181 work under the same human-acknowledged pre-existing RED. Independent of the sibling stage-3 PRs.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
