### PR TITLE
refactor: migrate smoke env overrides to in-file '# ENV:' declarations

### DIFF
--- a/config/build/profile_smoke.yaml
+++ b/config/build/profile_smoke.yaml
@@ -22,122 +22,19 @@ defaults:
   MPLCONFIGDIR: "/tmp/matplotlib"           # Writable config dir for matplotlib
 
 overrides:
-  # JAX likelihood functions test JIT compilation — need JAX enabled and full-size datasets
-  - pattern: "jax_likelihood_functions/"
-    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
-  # JAX substructure scripts test the full simulate_substructure / batched_simulate_substructure
-  # path with an explicit image_shape=(51,51). PYAUTO_SMALL_DATASETS=1 clamps the input grid
-  # to 15x15 (225 points) but image_shape is left alone, so the reshape inside
-  # simulate_substructure (substructure_util.py:168) raises a 225 vs 2601 TypeError.
-  # Same JAX-with-full-dataset pattern as jax_likelihood_functions/.
-  - pattern: "jax_substructure/"
-    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
-  # potential_correction/subhalo_recovery.py simulates its own 120x120
-  # dataset inline and asserts dkappa-recovery metrics whose thresholds are
-  # calibrated at that resolution — the 15x15 SMALL_DATASETS grid cap would
-  # break the mask/mesh geometry.
-  - pattern: "potential_correction/"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # Database scrape scripts need real search output on disk — no test env vars
+  # NOT migrated to an in-file declaration: this override unsets
+  # PYAUTO_DISABLE_JAX on database/scrape scripts that are NOT JAX-marked
+  # (general.py, scaling_relation.py). A `# ENV:` declaration applies to the
+  # release profile too, where PYAUTO_DISABLE_JAX defaults to "1" and the
+  # marker derivation only re-enables JAX for marked scripts — so declaring
+  # it here would flip these two scripts from numpy to JAX under release
+  # (a real behavioural change, not the provable no-op the migration requires).
+  # It therefore stays a smoke-only profile override (#187 Stage 2).
+  # All other former overrides here were pure declarable-var unsets and have
+  # migrated to in-file `# ENV:` declarations on their matched scripts.
   - pattern: "database/scrape/"
     unset:
       - PYAUTO_TEST_MODE
       - PYAUTO_SMALL_DATASETS
       - PYAUTO_DISABLE_JAX
       - PYAUTO_FAST_PLOTS
-  # These scripts load pre-committed FITS data at full resolution
-  - pattern: "database/scrape/scaling_relation"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "imaging/convolution"
-    unset: [PYAUTO_SMALL_DATASETS]
-  - pattern: "imaging/model_fit"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # imaging/visualization.py asserts subplot PNG / FITS files land on disk
-  # and loads pre-committed FITS at full resolution — both PYAUTO_FAST_PLOTS
-  # (which short-circuits savefig) and PYAUTO_SMALL_DATASETS must be unset.
-  - pattern: "imaging/visualization.py"
-    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  # visualization_jax exercises the jit-cached fit_for_visualization path
-  # (registered model + autoarray pytrees). It must run with JAX enabled —
-  # PYAUTO_DISABLE_JAX=1 would silently flip use_jax flags off and the
-  # script would no-op. Also asserts fit.png on disk so PYAUTO_FAST_PLOTS
-  # must be unset.
-  - pattern: "imaging/visualization_jax"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  # jax_grad/ scripts drive jax.value_and_grad + finite-difference gradient
-  # correctness checks. They need JAX enabled — PYAUTO_DISABLE_JAX=1 forces the
-  # numpy xp path while autodiff traces the likelihood, so the traced input is
-  # never differentiated: imaging_lp (positions path) raises
-  # TracerArrayConversionError; imaging_mge / imaging_pixelization return an
-  # all-zero gradient. They also need full-resolution float64 data for the FD
-  # comparison. (imaging_pixelization additionally spawns
-  # jax_likelihood_functions/imaging/simulator.py as a subprocess; under
-  # PYAUTO_SMALL_DATASETS=1 the simulator builds a slim 256 (16x16) array
-  # against a 441 (21x21) mask -> ArrayException. subprocess.run inherits
-  # os.environ, so unsetting the cap for the parent propagates to the
-  # simulator.) Same pattern as jax_likelihood_functions/.
-  - pattern: "jax_grad/"
-    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
-  # Model composition scripts assert prior_count for full-size MGE bases.
-  # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
-  - pattern: "model_composition/"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # interferometer/visualization.py asserts subplot PNG / FITS files exist
-  # on disk (PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray)
-  # and loads pre-committed FITS at full resolution with an explicit
-  # (100, 100) shape_native mask — the 15x15 SMALL_DATASETS cap would still
-  # apply, so both must be unset.
-  - pattern: "interferometer/visualization.py"
-    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  # interferometer/visualization_jax exercises the jit-cached
-  # fit_for_visualization path on the interferometer side. PYAUTO_DISABLE_JAX=1
-  # would silently flip use_jax flags off — script needs JAX enabled.
-  - pattern: "interferometer/visualization_jax"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  # modeling_visualization_jit{,_delaunay,_rectangular} test the JIT-cached
-  # visualization path: needs JAX enabled (Part 1 asserts log_likelihood is
-  # a jax.Array), the full-resolution mask, a real Nautilus run for Part 2,
-  # and savefig active (Part 2 asserts fit.png lands on disk).
-  - pattern: "imaging/modeling_visualization_jit"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
-  # interferometer/modeling_visualization_jit — same intent as the imaging
-  # analogue but for the interferometer JIT path.
-  - pattern: "interferometer/modeling_visualization_jit"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
-  # multi/visualization_imaging loads the 150x150 lens_sersic dataset from
-  # disk via Imaging.from_fits (which does not honour SMALL_DATASETS) and
-  # builds its mask via al.Mask2D.circular (which DOES cap to 15x15 under
-  # PYAUTO_SMALL_DATASETS=1, even when shape_native is explicit). The
-  # mismatch raises a (150,150) vs (15,15) broadcast error on apply_mask.
-  # The script does not run a non-linear search, so it is only useful at
-  # full resolution; just unset the cap.
-  - pattern: "multi/visualization_imaging"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # multi/dataset_model_parity_delaunay asserts the two-frame Delaunay parity
-  # (profile-baked vs DatasetModel) agrees within a ~0.2 log_likelihood pixel-
-  # sampling floor. PYAUTO_SMALL_DATASETS=1 caps the grid to 16x16, where that
-  # floor is meaningless (the frames disagree by ~90). CONFIRMED it agrees at
-  # full size (A0=-1144.359, A1=-1144.384); the parity test is only useful there.
-  - pattern: "multi/dataset_model_parity_delaunay"
-    unset: [PYAUTO_SMALL_DATASETS]
-  # point_source/visualization.py asserts fit.png lands on disk and uses a
-  # JSON point dataset (no FITS, no mask) — PYAUTO_FAST_PLOTS must be unset
-  # but PYAUTO_SMALL_DATASETS does not affect this script.
-  - pattern: "point_source/visualization.py"
-    unset: [PYAUTO_FAST_PLOTS]
-  # point_source/visualization_jax exercises the jit-cached
-  # fit_for_visualization path on the point-source side. Also asserts
-  # fit.png on disk so PYAUTO_FAST_PLOTS must be unset.
-  - pattern: "point_source/visualization_jax"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
-  # point_source/modeling_visualization_jit — live Nautilus + JIT path.
-  - pattern: "point_source/modeling_visualization_jit"
-    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
-  # cluster/visualization.py asserts 5 subplot PNGs land on disk
-  # (PYAUTO_FAST_PLOTS=1 short-circuits subplot_save() in PyAutoArray) and
-  # loads its data.fits at full resolution while asserting per-plane tangential
-  # critical-curve recovery on a full-extent 250x250 viz_grid — the 15x15
-  # SMALL_DATASETS cap would break the mask geometry. Both must be unset.
-  # (Also no_run-listed as SLOW: the curve computation is ~580s > 300s cap.)
-  - pattern: "cluster/visualization.py"
-    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]

--- a/scripts/cluster/visualization.py
+++ b/scripts/cluster/visualization.py
@@ -42,6 +42,9 @@ Run from the ``autolens_workspace_test`` repo root with the standard cache overr
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
         python scripts/cluster/visualization.py
 """
+# ENV: full_datasets real_plots
+# Asserts 5 subplot PNGs land on disk (needs real plots) and
+# recovers critical curves on a full-extent 250x250 grid.
 
 import shutil
 import subprocess

--- a/scripts/database/scrape/scaling_relation.py
+++ b/scripts/database/scrape/scaling_relation.py
@@ -35,6 +35,8 @@ __Structure__
 This test mirrors `general.py` exactly, adding only the scaling relation model
 for the extra galaxy.
 """
+# ENV: full_datasets
+# Loads pre-committed FITS data at full resolution.
 
 from astropy.io import fits
 import numpy as np

--- a/scripts/imaging/convolution.py
+++ b/scripts/imaging/convolution.py
@@ -14,6 +14,9 @@ use their simplest forms, a `RectangularAdaptDensity` `Pixelization` and `Consta
 
 Inversions are covered in detail in chapter 4 of the **HowToLens** lectures.
 """
+# ENV: full_datasets
+# Reads pre-committed full-resolution data; the SMALL_DATASETS 15x15
+# cap would break the mask/shape assertion.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/imaging/convolution_over_sampled.py
+++ b/scripts/imaging/convolution_over_sampled.py
@@ -18,6 +18,9 @@ Covers, at `convolve_over_sample_size=2` with s=1 parity checks:
 Library support shipped in PyAutoArray#355 (Convolver + dataset API), PyAutoArray#357 (inversion mapping
 formalism) and PyAutoGalaxy#481 (operate/image consumer + linear light profiles).
 """
+# ENV: full_datasets
+# Reads pre-committed full-resolution data; the SMALL_DATASETS 15x15
+# cap would break the mask/shape assertion.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/imaging/model_fit.py
+++ b/scripts/imaging/model_fit.py
@@ -14,6 +14,9 @@ use their simplest forms, a `RectangularAdaptDensity` `Pixelization` and `Consta
 
 Inversions are covered in detail in chapter 4 of the **HowToLens** lectures.
 """
+# ENV: full_datasets
+# Reads pre-committed FITS data at full resolution; SMALL_DATASETS
+# cap would mismatch the committed-shape mask.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/imaging/modeling_visualization_jit.py
+++ b/scripts/imaging/modeling_visualization_jit.py
@@ -28,6 +28,9 @@ This script deliberately opts in with
 workspace leave the flag at ``False`` and are therefore untouched by this
 change.
 """
+# ENV: real_output
+# JIT-cached visualization path: real search (Nautilus), JAX,
+# full-resolution mask and real savefig.
 
 import shutil
 import time

--- a/scripts/imaging/visualization.py
+++ b/scripts/imaging/visualization.py
@@ -32,6 +32,9 @@ Expected outputs are derived directly from the source code of:
   - autogalaxy/analysis/plotter.py          (Plotter: galaxies, inversion)
   - autogalaxy/imaging/plot/fit_imaging_plots.py
 """
+# ENV: full_datasets real_plots
+# Asserts subplot PNG / FITS land on disk (needs real plots) and
+# reads full-resolution data.
 
 import shutil
 import time

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -23,6 +23,9 @@ Scope
 - Reuses ``config_source/visualize/plots.yaml`` from ``visualization.py`` so
   only ``fit.png`` and ``tracer.png`` are attempted.
 """
+# ENV: jax full_datasets real_plots
+# JIT-cached fit_for_visualization path; needs JAX enabled, real
+# plots and full-resolution data.
 
 import shutil
 from os import path

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -28,6 +28,9 @@ This script deliberately opts in with
 in the workspace leave the flag at ``False`` and are therefore untouched by
 this change.
 """
+# ENV: real_output
+# Interferometer JIT visualization path: real search, JAX,
+# full-resolution mask and real savefig.
 
 import shutil
 import time

--- a/scripts/interferometer/visualization.py
+++ b/scripts/interferometer/visualization.py
@@ -32,6 +32,9 @@ Expected outputs are derived directly from the source code of:
   - autolens/analysis/plotter.py                        (Plotter: tracer, galaxies, inversion)
   - autogalaxy/analysis/plotter.py                      (Plotter: galaxies, inversion)
 """
+# ENV: full_datasets real_plots
+# Asserts subplot PNG / FITS land on disk (needs real plots) and
+# reads full-resolution data.
 
 import shutil
 from os import path

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -24,6 +24,9 @@ Scope
 - Re-uses the ``simple`` dataset from ``jax_likelihood_functions/interferometer``.
 - Uses the default plot config (no bespoke config_source override).
 """
+# ENV: jax full_datasets real_plots
+# JIT-cached fit_for_visualization path (interferometer); needs
+# JAX enabled, real plots and full-resolution data.
 
 import shutil
 from os import path

--- a/scripts/jax_grad/imaging_lp.py
+++ b/scripts/jax_grad/imaging_lp.py
@@ -20,6 +20,9 @@ evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
 consistency check at the base point so ``pure_callback`` constant-folding
 cannot fake the comparison.
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/imaging_mge.py
+++ b/scripts/jax_grad/imaging_mge.py
@@ -17,6 +17,9 @@ evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
 consistency check at the base point so ``pure_callback`` constant-folding
 cannot fake the comparison.
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/imaging_pixelization.py
+++ b/scripts/jax_grad/imaging_pixelization.py
@@ -60,6 +60,9 @@ mass/shear at pixelization over-sampling 1, where variant B is exactly flat.
 An eager figure-of-merit parity check against the matching linear mesh guards
 reconstruction quality.
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/interferometer.py
+++ b/scripts/jax_grad/interferometer.py
@@ -37,6 +37,9 @@ gradients are live and strictly FD-matched.
 See the audit README
 (`autolens_workspace_developer/jax_profiling/gradient/README.md`).
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/point_source.py
+++ b/scripts/jax_grad/point_source.py
@@ -26,6 +26,9 @@ zero, and the script asserts the positional parameters are live.
 
 Setup mirrors ``scripts/jax_likelihood_functions/point_source/source_plane.py``.
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/util.py
+++ b/scripts/jax_grad/util.py
@@ -26,6 +26,9 @@ into the compiled program, which fakes both values and (zero) gradients. If a
 jitted ``f`` is passed for speed, call ``assert_eager_jit_consistent`` first
 with the un-jitted function so the two agree at the base point.
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_grad/weak.py
+++ b/scripts/jax_grad/weak.py
@@ -17,6 +17,9 @@ gradient flow.
 Setup mirrors ``scripts/jax_likelihood_functions/weak/shear.py`` (the value
 parity script for PyAutoLens feature/weak-sigma-crit-jax, issue #590).
 """
+# ENV: jax full_datasets
+# Drive jax.value_and_grad + finite-difference gradient checks;
+# need JAX enabled and full-resolution float64 data.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/datacube/delaunay.py
+++ b/scripts/jax_likelihood_functions/datacube/delaunay.py
@@ -27,6 +27,9 @@ Path B re-runs the same vmap likelihood with ``TransformerNUFFT`` and asserts
 the same expected value — proves the cube path works with both DFT and NUFFT
 transformers.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/datacube/rectangular.py
+++ b/scripts/jax_likelihood_functions/datacube/rectangular.py
@@ -28,6 +28,9 @@ Path B re-runs the same vmap likelihood with ``TransformerNUFFT`` and asserts
 the same expected value — proves the cube path works with both DFT and NUFFT
 transformers.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/datacube/shared_preloads.py
+++ b/scripts/jax_likelihood_functions/datacube/shared_preloads.py
@@ -28,6 +28,9 @@ Run from the workspace root:
 
     python scripts/jax_likelihood_functions/datacube/shared_preloads.py
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax.numpy as jnp

--- a/scripts/jax_likelihood_functions/imaging/delaunay.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/delaunay_near_caustic.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_near_caustic.py
@@ -21,6 +21,9 @@ than the 1e-4 of the sibling scripts, because the point of PR #368 is that
 the mappings are EXACT (visibility walk), so the only residual is fp
 reduction ordering (~1e-13 relative, measured).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/lp.py
+++ b/scripts/jax_likelihood_functions/imaging/lp.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/mge.py
+++ b/scripts/jax_likelihood_functions/imaging/mge.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/mge_group.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/potential_correction.py
+++ b/scripts/jax_likelihood_functions/imaging/potential_correction.py
@@ -12,6 +12,9 @@ The technique is ported from the `potential_correction` package of Cao et al. 20
 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via
 https://github.com/caoxiaoyue/potential_correction_paper).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/imaging/rectangular.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/simulator.py
+++ b/scripts/jax_likelihood_functions/imaging/simulator.py
@@ -6,6 +6,9 @@ This script simulates `Imaging` of a strong lens where:
 
  - The resolution, PSF and S/N are representative of Hubble Space Telescope imaging.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/simulator_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/simulator_dspl.py
@@ -6,6 +6,9 @@ This script simulates `Imaging` of a strong lens where:
 
  - The resolution, PSF and S/N are representative of Hubble Space Telescope imaging.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/imaging/subhalo.py
+++ b/scripts/jax_likelihood_functions/imaging/subhalo.py
@@ -49,6 +49,9 @@ A regression of issue #498 will trip Scenario B's vmap assert. A
 regression of the Ludlow pure_callback path will trip Scenario C or D's
 vmap assert (or raise inside the callback under vmap).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/interferometer/delaunay.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay.py
@@ -8,6 +8,9 @@ of an `Interferometer` dataset with a model which uses a Delaunay pixelization s
 Mirrors `imaging/delaunay.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
@@ -9,6 +9,9 @@ Delaunay pixelization source.
 Mirrors `imaging/delaunay_mge.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/lp.py
+++ b/scripts/jax_likelihood_functions/interferometer/lp.py
@@ -9,6 +9,9 @@ Mirrors `imaging/lp.py` but uses interferometer dataset loading (real_space_mask
 Interferometer.from_fits, TransformerDFT) from `interferometer/rectangular.py`.
 No apply_over_sampling — interferometer does not oversample.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/interferometer/mge_group.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge_group.py
@@ -4,6 +4,9 @@ Func Grad: Interferometer MGE + Extra Galaxies
 Tests that JAX can compute batched log-likelihood evaluations for an interferometer
 model with extra galaxies, using the same dataset as interferometer/mge.py.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/potential_correction.py
+++ b/scripts/jax_likelihood_functions/interferometer/potential_correction.py
@@ -12,6 +12,9 @@ The technique is ported from the `potential_correction` package of Cao et al. 20
 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via
 https://github.com/caoxiaoyue/potential_correction_paper).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/rectangular.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
@@ -12,6 +12,9 @@ apply_over_sampling — interferometer does not oversample.
 
 The `should_simulate` bootstrap invokes `simulator_dspl.py` to generate the dataset.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
@@ -9,6 +9,9 @@ rectangular pixelization source.
 Mirrors `imaging/rectangular_mge.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
@@ -13,6 +13,9 @@ This is a copy of `interferometer/rectangular.py` with one additional line after
 The sparse NUFFT operator is aux state and must NOT be constructed inside the JIT
 trace. It is built once before analysis construction and carried as static state.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/interferometer/simulator.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator.py
@@ -19,6 +19,9 @@ __Model__
  - Lens: `Isothermal` mass + `ExternalShear`.
  - Source: `SersicCore` light profile (cored, avoiding over-sampling issues).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 from os import path
 from pathlib import Path

--- a/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
@@ -27,6 +27,9 @@ __Model__
 
 The redshifts match `imaging/simulator_dspl.py`.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 from os import path
 from pathlib import Path

--- a/scripts/jax_likelihood_functions/light_multipole/multipole.py
+++ b/scripts/jax_likelihood_functions/light_multipole/multipole.py
@@ -16,6 +16,9 @@ Mirrors ``imaging/lp.py`` but swaps the lens bulge for
 priors on the four multipole-component parameters (the library does not yet
 ship default priors for them — this keeps the script self-contained).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax.numpy as jnp

--- a/scripts/jax_likelihood_functions/multi/dataset_model.py
+++ b/scripts/jax_likelihood_functions/multi/dataset_model.py
@@ -23,6 +23,9 @@ Path layout follows ``multi/lp.py``: vmap evaluation through
 ``fitness._vmap`` and then a separate ``jax.jit`` wrap around
 ``instance_from_vector → log_likelihood_function``.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/delaunay.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay.py
@@ -19,6 +19,9 @@ parity. For pixelized sources, ``analysis.log_likelihood_function`` under
 ``use_jax=False`` (the JAX path matches ``fit.log_likelihood`` only when
 routed through ``fit_from``, which ``FactorGraphModel`` does not expose).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay_mge.py
@@ -13,6 +13,9 @@ Path A asserts ``vmap == JIT round-trip``; see ``rectangular.py`` for
 the rationale (pixelized ``log_likelihood_function`` differs between
 ``use_jax=True`` and ``use_jax=False``).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/lp.py
+++ b/scripts/jax_likelihood_functions/multi/lp.py
@@ -14,6 +14,9 @@ Path A uses ``jax.jit(factor_graph.log_likelihood_function)`` (not ``fit_from``
 — ``FactorGraphModel`` does not expose a ``fit_from`` method; it sums each
 child factor's log-likelihood).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/mge.py
+++ b/scripts/jax_likelihood_functions/multi/mge.py
@@ -9,6 +9,9 @@ Uses **option B** — per-band source MGE ``ell_comps`` priors via ``model.copy(
 ``af.GaussianPrior`` on each ``AnalysisFactor``. All other parameters (lens MGE bulge,
 lens mass, shear, source centres and intensities) remain shared across the g and r bands.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/mge_group.py
+++ b/scripts/jax_likelihood_functions/multi/mge_group.py
@@ -14,6 +14,9 @@ Path A uses ``jax.jit`` on a parameter-vector entry point that mirrors
 ``fitness._vmap`` (``instance_from_vector`` → ``log_likelihood_function``),
 because ``FactorGraphModel`` has no ``fit_from`` method.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/rectangular.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular.py
@@ -25,6 +25,9 @@ routed through ``fit_from``, which ``FactorGraphModel`` does not expose).
 Parametric-only scripts in this folder (``lp.py``, ``mge_group.py``)
 assert full NumPy/JAX parity.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular_mge.py
@@ -12,6 +12,9 @@ The MGE lens bulge, lens mass, shear, and mesh parameters remain shared.
 Path A asserts ``vmap == JIT round-trip``; see ``rectangular.py`` for
 the rationale.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/shared_preloads.py
+++ b/scripts/jax_likelihood_functions/multi/shared_preloads.py
@@ -32,6 +32,9 @@ Run from the workspace root:
 
     python scripts/jax_likelihood_functions/multi/shared_preloads.py
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 import numpy as np
 import jax

--- a/scripts/jax_likelihood_functions/multi/simulator.py
+++ b/scripts/jax_likelihood_functions/multi/simulator.py
@@ -7,6 +7,9 @@ the multi-wavelength JAX likelihood function tests in this folder.
 Each band shares the same lens mass but has its own source intensity,
 written to `dataset/multi/lens_sersic/`.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 from os import path
 import autolens as al

--- a/scripts/jax_likelihood_functions/point_source/image_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/image_plane.py
@@ -14,6 +14,9 @@ This variant is known to JIT end-to-end (see
 ``autolens_workspace_developer/jax_profiling/point_source/image_plane.py``),
 so ``jax.jit(analysis.fit_from)`` succeeds without falling back to a prefix.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -23,6 +23,9 @@ Operated light profiles offer an alternative approach, whereby the light profile
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/point_source/simulator.py
+++ b/scripts/jax_likelihood_functions/point_source/simulator.py
@@ -13,6 +13,9 @@ __Model__
  - Lens: `Isothermal` mass (centre near origin, einstein_radius=1.6).
  - Source: Point source at (0.07, 0.07).
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 from os import path
 import numpy as np

--- a/scripts/jax_likelihood_functions/point_source/source_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/source_plane.py
@@ -22,6 +22,9 @@ BLOCKER line and continues, so the eager NumPy regression assertion is still
 exercised.  Once the upstream xp-propagation fix lands, the JIT path will
 succeed without modifying this script.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/weak/shear.py
+++ b/scripts/jax_likelihood_functions/weak/shear.py
@@ -11,6 +11,9 @@ registration added by PyAutoLens feature/weak-sigma-crit-jax (issue #590). The r
 scale factors are concrete per-dataset constants, so a dataset carrying per-galaxy redshifts
 exercises the eager-scaling + traced-statistics combination too.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 # %matplotlib inline
 # from pyprojroot import here

--- a/scripts/jax_likelihood_functions/weak/simulator.py
+++ b/scripts/jax_likelihood_functions/weak/simulator.py
@@ -4,6 +4,9 @@ Simulator for the weak-lensing JAX parity scripts.
 Writes a seeded, noise-controlled `WeakDataset` to `dataset/weak/simple/dataset.json` so the
 `shear.py` vmap-parity regression constant is stable across runs.
 """
+# ENV: jax full_datasets
+# JAX likelihood functions test JIT compilation; need JAX enabled
+# and full-size datasets.
 
 from pathlib import Path
 

--- a/scripts/jax_substructure/test_batched_simulate.py
+++ b/scripts/jax_substructure/test_batched_simulate.py
@@ -7,6 +7,9 @@ produces identical results to calling simulate_substructure in a loop.
 
 Ref: PyAutoLens#542, prompt 4.
 """
+# ENV: jax full_datasets
+# Tests the full simulate_substructure path at image_shape=(51,51);
+# need JAX enabled and full-size datasets (the 15x15 cap raises).
 
 import numpy as np
 import jax

--- a/scripts/jax_substructure/test_scan_multiplane.py
+++ b/scripts/jax_substructure/test_scan_multiplane.py
@@ -6,6 +6,9 @@ Validates that traced_grids_via_scan (jax.lax.scan path) reproduces the
 existing Python-loop Tracer path for a 4-plane system with LOS halos,
 a macro lens, and negative kappa sheets. Ref: PyAutoLens#542, prompt 2.
 """
+# ENV: jax full_datasets
+# Tests the full simulate_substructure path at image_shape=(51,51);
+# need JAX enabled and full-size datasets (the 15x15 cap raises).
 
 import numpy as np
 import jax

--- a/scripts/jax_substructure/test_simulate_e2e.py
+++ b/scripts/jax_substructure/test_simulate_e2e.py
@@ -8,6 +8,9 @@ Compares the deterministic (no-noise) lensed+convolved image.
 
 Ref: PyAutoLens#542, prompt 3.
 """
+# ENV: jax full_datasets
+# Tests the full simulate_substructure path at image_shape=(51,51);
+# need JAX enabled and full-size datasets (the 15x15 cap raises).
 
 import numpy as np
 import jax

--- a/scripts/model_composition/multi_galaxy_mge.py
+++ b/scripts/model_composition/multi_galaxy_mge.py
@@ -28,6 +28,9 @@ __Contents__
 - **Serialization Round-Trip:** dict/from_dict preserves prior count and path structure.
 - **Model Info:** Human-readable info string contains expected component names.
 """
+# ENV: full_datasets
+# Asserts prior_count for full-size MGE bases; SMALL_DATASETS
+# reduces total_gaussians and changes prior_count.
 
 import autofit as af
 import autolens as al

--- a/scripts/multi/dataset_model_parity_delaunay.py
+++ b/scripts/multi/dataset_model_parity_delaunay.py
@@ -39,6 +39,9 @@ Qiuhan saw on ``dev_Q``. Without rotating the cached mesh-grid in lockstep
 with the data grid, B1 would diverge from A1 by ~1 or more in log-likelihood
 even for the small (12 degree) rotation used here.
 """
+# ENV: full_datasets
+# Two-frame Delaunay parity is only meaningful at full size; the
+# 16x16 cap makes the log_likelihood floor meaningless.
 
 import numpy as np
 import autoarray as aa

--- a/scripts/multi/visualization_imaging.py
+++ b/scripts/multi/visualization_imaging.py
@@ -31,6 +31,9 @@ Run from the ``autolens_workspace_test`` repo root:
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
         python scripts/multi/visualization_imaging.py
 """
+# ENV: full_datasets
+# Loads a 150x150 dataset and builds its mask via Mask2D.circular
+# which caps to 15x15; only useful at full resolution.
 
 import shutil
 from os import path

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -26,6 +26,9 @@ This script deliberately opts in with
 Default model-fit scripts elsewhere in the workspace leave the flag at
 ``False`` and are therefore untouched.
 """
+# ENV: real_output
+# Live Nautilus + JIT point-source path: real search, JAX,
+# full-resolution data and real savefig.
 
 import shutil
 import time

--- a/scripts/point_source/visualization.py
+++ b/scripts/point_source/visualization.py
@@ -13,6 +13,9 @@ same model that is proven to JIT end-to-end in
 
 No ``try/except`` — any failure in the visualizer surfaces immediately.
 """
+# ENV: real_plots
+# Asserts fit.png lands on disk (needs real plots); uses a JSON
+# point dataset unaffected by SMALL_DATASETS.
 
 import shutil
 from pathlib import Path

--- a/scripts/point_source/visualization_jax.py
+++ b/scripts/point_source/visualization_jax.py
@@ -20,6 +20,9 @@ Scope
 - Re-uses the ``simple/point_dataset_positions_only.json`` dataset.
 - No ``try/except`` wrapper — failure surfaces immediately.
 """
+# ENV: jax full_datasets real_plots
+# JIT-cached fit_for_visualization path (point source); needs JAX
+# enabled, real plots and full-resolution data.
 
 import shutil
 from pathlib import Path

--- a/scripts/potential_correction/subhalo_recovery.py
+++ b/scripts/potential_correction/subhalo_recovery.py
@@ -13,6 +13,9 @@ https://github.com/caoxiaoyue/potential_correction_paper), mirroring its demo re
 200x200 demo dataset the merged implementation recovers corr(dkappa_rec, dkappa_true) = 0.77 with the peak 0.21"
 from the true subhalo (one-shot); the reduced problem here asserts conservative thresholds.
 """
+# ENV: full_datasets
+# Simulates a 120x120 dataset inline with resolution-calibrated
+# dkappa thresholds; the 15x15 cap breaks the mesh geometry.
 
 import numpy as np
 

--- a/scripts/potential_correction/subhalo_recovery_interferometer.py
+++ b/scripts/potential_correction/subhalo_recovery_interferometer.py
@@ -21,6 +21,9 @@ Cites Cao et al. 2025 (https://github.com/caoxiaoyue/lensing_potential_correctio
 https://github.com/caoxiaoyue/potential_correction_paper); methodology per the JVAS B1938+666 detections
 (Powell et al. 2025; Vegetti et al. 2026).
 """
+# ENV: full_datasets
+# Simulates a 120x120 dataset inline with resolution-calibrated
+# dkappa thresholds; the 15x15 cap breaks the mesh geometry.
 
 import numpy as np
 


### PR DESCRIPTION
## Overview

Phase 1b migration (PyAutoLabs/PyAutoHands#187; mechanism PR: PyAutoLabs/PyAutoHands#188 — merge that first). Per-script env requirements move from pattern-keyed override blocks in `config/build/profile_smoke.yaml` into the scripts themselves as `# ENV: <tokens>` declarations, so a moved or renamed script carries its env config with it instead of silently orphaning an override. Each override's rationale comment moved into the script beside its declaration. Overrides that cannot be expressed as declarations (`set:` clauses, non-declarable vars, or `DISABLE_JAX` unsets matching non-JAX-marked scripts) remain pattern-keyed by design.

## Scripts Changed

- `config/build/profile_smoke.yaml` — migrated override blocks deleted (mixed overrides shrunk to their non-declarable remainder).
- `scripts/**` — matched scripts gain a one-line `# ENV:` declaration + condensed rationale comment. (User-workspace PRs also touch `config/build/profile_release.yaml` where a now-redundant `guides/results/` override was removed — the declaration covers it in every profile.)

Per-repo detail is in the PR's file list; the per-repo migration table (migrated / split / kept, with reasons) is on PyAutoLabs/PyAutoHands#187.

## Verification

- **Smoke resolution byte-identical to HEAD** for every script in this repo (empty-base resolved-env diff, old profile vs new profile + declarations).
- Release diffs (where a release profile exists) exclusively in the reader-verified `"0"` → absent equivalence class (absent ≡ "0"/off for all four managed vars — file:line evidence in PyAutoHands `docs/env_profile_redesign.md` §10).
- Validator: **0 errors with all strict flags on, including `--strict-declarations`**.

## Ship note

Shipped under human-acknowledged Heart YELLOW: `workspace validation not passing (13 failed, 2026-07-21T19-05-22Z)`; `33 stale parked script(s)` — both pre-existing and unrelated.

Linked issue: PyAutoLabs/PyAutoHands#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb
