### PR TITLE
refactor: fold __Env__ into the adjacent docstring

### DIFF
--- a/scripts/cluster/visualization.py
+++ b/scripts/cluster/visualization.py
@@ -41,9 +41,7 @@ Run from the ``autolens_workspace_test`` repo root with the standard cache overr
 
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
         python scripts/cluster/visualization.py
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/database/scrape/scaling_relation.py
+++ b/scripts/database/scrape/scaling_relation.py
@@ -34,9 +34,7 @@ __Structure__
 
 This test mirrors `general.py` exactly, adding only the scaling relation model
 for the extra galaxy.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/convolution.py
+++ b/scripts/imaging/convolution.py
@@ -13,9 +13,7 @@ this reconstruction to be smooth. This uses `Pixelization`  objects and in this 
 use their simplest forms, a `RectangularAdaptDensity` `Pixelization` and `Constant` `Regularization`.scheme.
 
 Inversions are covered in detail in chapter 4 of the **HowToLens** lectures.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/convolution_over_sampled.py
+++ b/scripts/imaging/convolution_over_sampled.py
@@ -17,9 +17,7 @@ Covers, at `convolve_over_sample_size=2` with s=1 parity checks:
 
 Library support shipped in PyAutoArray#355 (Convolver + dataset API), PyAutoArray#357 (inversion mapping
 formalism) and PyAutoGalaxy#481 (operate/image consumer + linear light profiles).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/model_fit.py
+++ b/scripts/imaging/model_fit.py
@@ -13,9 +13,7 @@ this reconstruction to be smooth. This uses `Pixelization`  objects and in this 
 use their simplest forms, a `RectangularAdaptDensity` `Pixelization` and `Constant` `Regularization`.scheme.
 
 Inversions are covered in detail in chapter 4 of the **HowToLens** lectures.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/modeling_visualization_jit.py
+++ b/scripts/imaging/modeling_visualization_jit.py
@@ -27,9 +27,7 @@ This script deliberately opts in with
 ``AnalysisImaging(use_jax=True)``. Default model-fit scripts elsewhere in the
 workspace leave the flag at ``False`` and are therefore untouched by this
 change.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/visualization.py
+++ b/scripts/imaging/visualization.py
@@ -31,9 +31,7 @@ Expected outputs are derived directly from the source code of:
   - autolens/analysis/plotter.py            (Plotter: tracer, galaxies, inversion)
   - autogalaxy/analysis/plotter.py          (Plotter: galaxies, inversion)
   - autogalaxy/imaging/plot/fit_imaging_plots.py
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -22,9 +22,7 @@ Scope
 - Re-uses the ``jax_test`` dataset from ``jax_likelihood_functions/imaging``.
 - Reuses ``config_source/visualize/plots.yaml`` from ``visualization.py`` so
   only ``fit.png`` and ``tracer.png`` are attempted.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/interferometer/modeling_visualization_jit.py
+++ b/scripts/interferometer/modeling_visualization_jit.py
@@ -27,9 +27,7 @@ This script deliberately opts in with
 ``AnalysisInterferometer(use_jax=True)``. Default model-fit scripts elsewhere
 in the workspace leave the flag at ``False`` and are therefore untouched by
 this change.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/interferometer/visualization.py
+++ b/scripts/interferometer/visualization.py
@@ -31,9 +31,7 @@ Expected outputs are derived directly from the source code of:
   - autogalaxy/interferometer/plot/fit_interferometer_plots.py (fits_galaxy_images, fits_dirty_images)
   - autolens/analysis/plotter.py                        (Plotter: tracer, galaxies, inversion)
   - autogalaxy/analysis/plotter.py                      (Plotter: galaxies, inversion)
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -23,9 +23,7 @@ Scope
 - Calls ``VisualizerInterferometer.visualize`` only (not ``visualize_before_fit``).
 - Re-uses the ``simple`` dataset from ``jax_likelihood_functions/interferometer``.
 - Uses the default plot config (no bespoke config_source override).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/imaging_lp.py
+++ b/scripts/jax_grad/imaging_lp.py
@@ -19,9 +19,7 @@ Autodiff runs on the eager (un-jitted) likelihood; the finite-difference
 evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
 consistency check at the base point so ``pure_callback`` constant-folding
 cannot fake the comparison.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/imaging_mge.py
+++ b/scripts/jax_grad/imaging_mge.py
@@ -16,9 +16,7 @@ Autodiff runs on the eager (un-jitted) likelihood; the finite-difference
 evaluations use a jitted likelihood for speed, guarded by an eager-vs-jit
 consistency check at the base point so ``pure_callback`` constant-folding
 cannot fake the comparison.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/imaging_pixelization.py
+++ b/scripts/jax_grad/imaging_pixelization.py
@@ -59,9 +59,7 @@ absent, so the strict FD comparison runs on ALL parameters — including
 mass/shear at pixelization over-sampling 1, where variant B is exactly flat.
 An eager figure-of-merit parity check against the matching linear mesh guards
 reconstruction quality.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/interferometer.py
+++ b/scripts/jax_grad/interferometer.py
@@ -36,9 +36,7 @@ gradients are live and strictly FD-matched.
 
 See the audit README
 (`autolens_workspace_developer/jax_profiling/gradient/README.md`).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/point_source.py
+++ b/scripts/jax_grad/point_source.py
@@ -25,9 +25,7 @@ legitimately zero gradients — both autodiff and finite differences agree on
 zero, and the script asserts the positional parameters are live.
 
 Setup mirrors ``scripts/jax_likelihood_functions/point_source/source_plane.py``.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/util.py
+++ b/scripts/jax_grad/util.py
@@ -25,9 +25,7 @@ Under a single JIT trace, ``jax.pure_callback`` results can be constant-folded
 into the compiled program, which fakes both values and (zero) gradients. If a
 jitted ``f`` is passed for speed, call ``assert_eager_jit_consistent`` first
 with the un-jitted function so the two agree at the base point.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_grad/weak.py
+++ b/scripts/jax_grad/weak.py
@@ -16,9 +16,7 @@ gradient flow.
 
 Setup mirrors ``scripts/jax_likelihood_functions/weak/shear.py`` (the value
 parity script for PyAutoLens feature/weak-sigma-crit-jax, issue #590).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/datacube/delaunay.py
+++ b/scripts/jax_likelihood_functions/datacube/delaunay.py
@@ -26,9 +26,7 @@ numerical path than under ``use_jax=False`` (the JAX path matches
 Path B re-runs the same vmap likelihood with ``TransformerNUFFT`` and asserts
 the same expected value — proves the cube path works with both DFT and NUFFT
 transformers.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/datacube/rectangular.py
+++ b/scripts/jax_likelihood_functions/datacube/rectangular.py
@@ -27,9 +27,7 @@ numerical path than under ``use_jax=False`` (the JAX path matches
 Path B re-runs the same vmap likelihood with ``TransformerNUFFT`` and asserts
 the same expected value — proves the cube path works with both DFT and NUFFT
 transformers.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/datacube/shared_preloads.py
+++ b/scripts/jax_likelihood_functions/datacube/shared_preloads.py
@@ -27,9 +27,7 @@ numerical path under `use_jax=True` than under `use_jax=False` (see
 Run from the workspace root:
 
     python scripts/jax_likelihood_functions/datacube/shared_preloads.py
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/delaunay.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_mge.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/delaunay_near_caustic.py
+++ b/scripts/jax_likelihood_functions/imaging/delaunay_near_caustic.py
@@ -20,9 +20,7 @@ Asserts eager (xp=np) == jit == every vmap lane at rtol=1e-8 — far tighter
 than the 1e-4 of the sibling scripts, because the point of PR #368 is that
 the mappings are EXACT (visibility walk), so the only residual is fp
 reduction ordering (~1e-13 relative, measured).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/lp.py
+++ b/scripts/jax_likelihood_functions/imaging/lp.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/mge.py
+++ b/scripts/jax_likelihood_functions/imaging/mge.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/mge_group.py
+++ b/scripts/jax_likelihood_functions/imaging/mge_group.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/potential_correction.py
+++ b/scripts/jax_likelihood_functions/imaging/potential_correction.py
@@ -11,9 +11,7 @@ jit-compilability.
 The technique is ported from the `potential_correction` package of Cao et al. 2025
 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via
 https://github.com/caoxiaoyue/potential_correction_paper).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/rectangular.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_dspl.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/imaging/rectangular_mge.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/simulator.py
+++ b/scripts/jax_likelihood_functions/imaging/simulator.py
@@ -5,9 +5,7 @@ Simulator: HST
 This script simulates `Imaging` of a strong lens where:
 
  - The resolution, PSF and S/N are representative of Hubble Space Telescope imaging.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/simulator_dspl.py
+++ b/scripts/jax_likelihood_functions/imaging/simulator_dspl.py
@@ -5,9 +5,7 @@ Simulator: HST
 This script simulates `Imaging` of a strong lens where:
 
  - The resolution, PSF and S/N are representative of Hubble Space Telescope imaging.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/imaging/subhalo.py
+++ b/scripts/jax_likelihood_functions/imaging/subhalo.py
@@ -48,9 +48,7 @@ exits non-zero.
 A regression of issue #498 will trip Scenario B's vmap assert. A
 regression of the Ludlow pure_callback path will trip Scenario C or D's
 vmap assert (or raise inside the callback under vmap).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/delaunay.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay.py
@@ -7,9 +7,7 @@ of an `Interferometer` dataset with a model which uses a Delaunay pixelization s
 
 Mirrors `imaging/delaunay.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/delaunay_mge.py
@@ -8,9 +8,7 @@ Delaunay pixelization source.
 
 Mirrors `imaging/delaunay_mge.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/lp.py
+++ b/scripts/jax_likelihood_functions/interferometer/lp.py
@@ -8,9 +8,7 @@ of an `Interferometer` dataset with a model which uses a parametric Sersic sourc
 Mirrors `imaging/lp.py` but uses interferometer dataset loading (real_space_mask,
 Interferometer.from_fits, TransformerDFT) from `interferometer/rectangular.py`.
 No apply_over_sampling — interferometer does not oversample.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/mge_group.py
+++ b/scripts/jax_likelihood_functions/interferometer/mge_group.py
@@ -3,9 +3,7 @@ Func Grad: Interferometer MGE + Extra Galaxies
 ===============================================
 Tests that JAX can compute batched log-likelihood evaluations for an interferometer
 model with extra galaxies, using the same dataset as interferometer/mge.py.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/potential_correction.py
+++ b/scripts/jax_likelihood_functions/interferometer/potential_correction.py
@@ -11,9 +11,7 @@ the iterative engine are checked for numpy/JAX agreement on the visibility-scale
 The technique is ported from the `potential_correction` package of Cao et al. 2025
 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via
 https://github.com/caoxiaoyue/potential_correction_paper).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/rectangular.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_dspl.py
@@ -11,9 +11,7 @@ via `Interferometer.from_fits` and uses `AnalysisInterferometer`. No
 apply_over_sampling — interferometer does not oversample.
 
 The `should_simulate` bootstrap invokes `simulator_dspl.py` to generate the dataset.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_mge.py
@@ -8,9 +8,7 @@ rectangular pixelization source.
 
 Mirrors `imaging/rectangular_mge.py` but uses interferometer dataset loading and
 `AnalysisInterferometer`. No apply_over_sampling — interferometer does not oversample.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
+++ b/scripts/jax_likelihood_functions/interferometer/rectangular_sparse.py
@@ -12,9 +12,7 @@ This is a copy of `interferometer/rectangular.py` with one additional line after
 
 The sparse NUFFT operator is aux state and must NOT be constructed inside the JIT
 trace. It is built once before analysis construction and carried as static state.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/simulator.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator.py
@@ -18,9 +18,7 @@ __Model__
 
  - Lens: `Isothermal` mass + `ExternalShear`.
  - Source: `SersicCore` light profile (cored, avoiding over-sampling issues).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
+++ b/scripts/jax_likelihood_functions/interferometer/simulator_dspl.py
@@ -26,9 +26,7 @@ __Model__
  - Source at z=2.0: `SersicCore` light profile.
 
 The redshifts match `imaging/simulator_dspl.py`.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/light_multipole/multipole.py
+++ b/scripts/jax_likelihood_functions/light_multipole/multipole.py
@@ -15,9 +15,7 @@ Mirrors ``imaging/lp.py`` but swaps the lens bulge for
 ``al.lp_linear.SersicMultipole`` and sets explicit ``TuplePrior`` Gaussian
 priors on the four multipole-component parameters (the library does not yet
 ship default priors for them — this keeps the script self-contained).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/dataset_model.py
+++ b/scripts/jax_likelihood_functions/multi/dataset_model.py
@@ -22,9 +22,7 @@ behaviour — this script is the regression marker for that path.
 Path layout follows ``multi/lp.py``: vmap evaluation through
 ``fitness._vmap`` and then a separate ``jax.jit`` wrap around
 ``instance_from_vector → log_likelihood_function``.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/delaunay.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay.py
@@ -18,9 +18,7 @@ parity. For pixelized sources, ``analysis.log_likelihood_function`` under
 ``use_jax=True`` takes a different numerical path than under
 ``use_jax=False`` (the JAX path matches ``fit.log_likelihood`` only when
 routed through ``fit_from``, which ``FactorGraphModel`` does not expose).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay_mge.py
@@ -12,9 +12,7 @@ The MGE lens bulge, lens mass, shear, and mesh parameters remain shared.
 Path A asserts ``vmap == JIT round-trip``; see ``rectangular.py`` for
 the rationale (pixelized ``log_likelihood_function`` differs between
 ``use_jax=True`` and ``use_jax=False``).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/lp.py
+++ b/scripts/jax_likelihood_functions/multi/lp.py
@@ -13,9 +13,7 @@ parameters (lens bulge, lens mass, shear, source bulge aside from
 Path A uses ``jax.jit(factor_graph.log_likelihood_function)`` (not ``fit_from``
 — ``FactorGraphModel`` does not expose a ``fit_from`` method; it sums each
 child factor's log-likelihood).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/mge.py
+++ b/scripts/jax_likelihood_functions/multi/mge.py
@@ -8,9 +8,7 @@ are fitted simultaneously with an Isothermal+ExternalShear lens mass and an MGE 
 Uses **option B** — per-band source MGE ``ell_comps`` priors via ``model.copy()`` +
 ``af.GaussianPrior`` on each ``AnalysisFactor``. All other parameters (lens MGE bulge,
 lens mass, shear, source centres and intensities) remain shared across the g and r bands.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/mge_group.py
+++ b/scripts/jax_likelihood_functions/multi/mge_group.py
@@ -13,9 +13,7 @@ the g and r bands.
 Path A uses ``jax.jit`` on a parameter-vector entry point that mirrors
 ``fitness._vmap`` (``instance_from_vector`` → ``log_likelihood_function``),
 because ``FactorGraphModel`` has no ``fit_from`` method.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/rectangular.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular.py
@@ -24,9 +24,7 @@ parity. For pixelized sources, ``analysis.log_likelihood_function`` under
 routed through ``fit_from``, which ``FactorGraphModel`` does not expose).
 Parametric-only scripts in this folder (``lp.py``, ``mge_group.py``)
 assert full NumPy/JAX parity.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular_mge.py
@@ -11,9 +11,7 @@ The MGE lens bulge, lens mass, shear, and mesh parameters remain shared.
 
 Path A asserts ``vmap == JIT round-trip``; see ``rectangular.py`` for
 the rationale.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/shared_preloads.py
+++ b/scripts/jax_likelihood_functions/multi/shared_preloads.py
@@ -31,9 +31,7 @@ pixelized sources.
 Run from the workspace root:
 
     python scripts/jax_likelihood_functions/multi/shared_preloads.py
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/multi/simulator.py
+++ b/scripts/jax_likelihood_functions/multi/simulator.py
@@ -6,9 +6,7 @@ the multi-wavelength JAX likelihood function tests in this folder.
 
 Each band shares the same lens mass but has its own source intensity,
 written to `dataset/multi/lens_sersic/`.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/point_source/image_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/image_plane.py
@@ -13,9 +13,7 @@ image-plane coordinates.
 This variant is known to JIT end-to-end (see
 ``autolens_workspace_developer/jax_profiling/point_source/image_plane.py``),
 so ``jax.jit(analysis.fit_from)`` succeeds without falling back to a prefix.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/point_source/point.py
+++ b/scripts/jax_likelihood_functions/point_source/point.py
@@ -22,9 +22,7 @@ compact model emission lands in.
 Operated light profiles offer an alternative approach, whereby the light profile is assumed to have already been
 convolved with the PSF. This operated light profile is then fitted directly to the point-source emission, which as
 discussed above shows the PSF features.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/point_source/simulator.py
+++ b/scripts/jax_likelihood_functions/point_source/simulator.py
@@ -12,9 +12,7 @@ __Model__
 
  - Lens: `Isothermal` mass (centre near origin, einstein_radius=1.6).
  - Source: Point source at (0.07, 0.07).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/point_source/source_plane.py
+++ b/scripts/jax_likelihood_functions/point_source/source_plane.py
@@ -21,9 +21,7 @@ A JIT fails with ``TracerArrayConversionError`` the script prints a clear
 BLOCKER line and continues, so the eager NumPy regression assertion is still
 exercised.  Once the upstream xp-propagation fix lands, the JIT path will
 succeed without modifying this script.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/weak/shear.py
+++ b/scripts/jax_likelihood_functions/weak/shear.py
@@ -10,9 +10,7 @@ Covers the ``FitWeak`` xp-threaded statistics and the ``AnalysisWeak._register_f
 registration added by PyAutoLens feature/weak-sigma-crit-jax (issue #590). The redshift
 scale factors are concrete per-dataset constants, so a dataset carrying per-galaxy redshifts
 exercises the eager-scaling + traced-statistics combination too.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_likelihood_functions/weak/simulator.py
+++ b/scripts/jax_likelihood_functions/weak/simulator.py
@@ -3,9 +3,7 @@ Simulator for the weak-lensing JAX parity scripts.
 
 Writes a seeded, noise-controlled `WeakDataset` to `dataset/weak/simple/dataset.json` so the
 `shear.py` vmap-parity regression constant is stable across runs.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_substructure/test_batched_simulate.py
+++ b/scripts/jax_substructure/test_batched_simulate.py
@@ -6,9 +6,7 @@ Validates that batched_simulate_substructure (vmap over realizations)
 produces identical results to calling simulate_substructure in a loop.
 
 Ref: PyAutoLens#542, prompt 4.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_substructure/test_scan_multiplane.py
+++ b/scripts/jax_substructure/test_scan_multiplane.py
@@ -5,9 +5,7 @@ Test: scan-based multi-plane ray-tracing
 Validates that traced_grids_via_scan (jax.lax.scan path) reproduces the
 existing Python-loop Tracer path for a 4-plane system with LOS halos,
 a macro lens, and negative kappa sheets. Ref: PyAutoLens#542, prompt 2.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/jax_substructure/test_simulate_e2e.py
+++ b/scripts/jax_substructure/test_simulate_e2e.py
@@ -7,9 +7,7 @@ image consistent with the existing SimulatorImaging.via_tracer_from path.
 Compares the deterministic (no-noise) lensed+convolved image.
 
 Ref: PyAutoLens#542, prompt 3.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/model_composition/multi_galaxy_mge.py
+++ b/scripts/model_composition/multi_galaxy_mge.py
@@ -27,9 +27,7 @@ __Contents__
 - **Identifier Stability:** Hardcoded regression anchor for the full model.
 - **Serialization Round-Trip:** dict/from_dict preserves prior count and path structure.
 - **Model Info:** Human-readable info string contains expected component names.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/multi/dataset_model_parity_delaunay.py
+++ b/scripts/multi/dataset_model_parity_delaunay.py
@@ -38,9 +38,7 @@ This is the test that catches the "weird source reconstruction" failure mode
 Qiuhan saw on ``dev_Q``. Without rotating the cached mesh-grid in lockstep
 with the data grid, B1 would diverge from A1 by ~1 or more in log-likelihood
 even for the small (12 degree) rotation used here.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/multi/visualization_imaging.py
+++ b/scripts/multi/visualization_imaging.py
@@ -30,9 +30,7 @@ Run from the ``autolens_workspace_test`` repo root:
 
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
         python scripts/multi/visualization_imaging.py
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/point_source/modeling_visualization_jit.py
+++ b/scripts/point_source/modeling_visualization_jit.py
@@ -25,9 +25,7 @@ This script deliberately opts in with
 ``AnalysisPoint(use_jax=True)``.
 Default model-fit scripts elsewhere in the workspace leave the flag at
 ``False`` and are therefore untouched.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/point_source/visualization.py
+++ b/scripts/point_source/visualization.py
@@ -12,9 +12,7 @@ same model that is proven to JIT end-to-end in
 ``scripts/jax_likelihood_functions/point_source/image_plane.py``.
 
 No ``try/except`` — any failure in the visualizer surfaces immediately.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/point_source/visualization_jax.py
+++ b/scripts/point_source/visualization_jax.py
@@ -19,9 +19,7 @@ Scope
 - Calls ``VisualizerPoint.visualize`` only (not ``visualize_before_fit``).
 - Re-uses the ``simple/point_dataset_positions_only.json`` dataset.
 - No ``try/except`` wrapper — failure surfaces immediately.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/potential_correction/subhalo_recovery.py
+++ b/scripts/potential_correction/subhalo_recovery.py
@@ -12,9 +12,7 @@ This is the workspace-level parity anchor of the port of Cao et al. 2025's `pote
 https://github.com/caoxiaoyue/potential_correction_paper), mirroring its demo reconstruction. On the reference
 200x200 demo dataset the merged implementation recovers corr(dkappa_rec, dkappa_true) = 0.77 with the peak 0.21"
 from the true subhalo (one-shot); the reduced problem here asserts conservative thresholds.
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).

--- a/scripts/potential_correction/subhalo_recovery_interferometer.py
+++ b/scripts/potential_correction/subhalo_recovery_interferometer.py
@@ -20,9 +20,7 @@ future realistic-uv-coverage validation campaign (the B1938+666 configuration of
 Cites Cao et al. 2025 (https://github.com/caoxiaoyue/lensing_potential_correction; cite via
 https://github.com/caoxiaoyue/potential_correction_paper); methodology per the JVAS B1938+666 detections
 (Powell et al. 2025; Vegetti et al. 2026).
-"""
 
-"""
 __Env__
 
 Test-harness configuration (PyAutoHands docs/env_profile_redesign.md §10).


### PR DESCRIPTION
## Overview

Refinement 2 of PyAutoLabs/PyAutoHands#189 (parser/strip support: PyAutoLabs/PyAutoHands#191 — merge that first): the standalone `__Env__` docstring violated the workspace doctrine — multiple `__Section__` headers belong in one docstring, not a `"""` close-then-reopen pair. `__Env__` now sits as the **last section inside the adjacent docstring**: the final docstring in user-facing scripts, the module docstring in `*_test` scripts. A standalone block remains only where a script has no adjacent docstring.

## Scripts Changed

- `scripts/**` — every script carrying a standalone `__Env__` docstring has it folded into the adjacent docstring (see file list). No config files touched.

## Verification

- Resolved-env diff vs HEAD (empty base, both profiles): **identical for every script** — pure syntax move.
- (User workspaces) real notebook generation on sampled scripts: zero `__Env__`/`ENV:` leakage; the host docstring's prose renders unchanged.
- All-strict validator: 0 errors.

## Ship note

Same human-acknowledged Heart YELLOW lineage as the #189 ship (workspace-validation backlog + stale parks, pre-existing).

Linked issue: PyAutoLabs/PyAutoHands#189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRQH5HrmMPfpWkmfh3ysJb
