### PR TITLE
test: re-derive multi rectangular reference LLs for the kernel-CDF meshes

### DIFF
--- a/scripts/multi/jax_likelihood/rectangular.py
+++ b/scripts/multi/jax_likelihood/rectangular.py
@@ -213,7 +213,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 # linear-algebra reduction order change across JAX releases. That is convergence
 # jitter, not a correctness regression. The EXACT, JAX-version-robust check is the
 # vmap == jit round-trip asserted below.
-EXPECTED_VMAP_LOG_LIKELIHOOD = -12928.70087095
+EXPECTED_VMAP_LOG_LIKELIHOOD = -8903.89296045
 
 np.testing.assert_allclose(
     np.array(result),

--- a/scripts/multi/jax_likelihood/rectangular_mge.py
+++ b/scripts/multi/jax_likelihood/rectangular_mge.py
@@ -197,7 +197,7 @@ print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
 # rectangular script (~2.6e-4), as the MGE basis amplifies the NNLS/linear-algebra
 # reduction-order jitter. Convergence jitter, not a regression. The EXACT,
 # JAX-version-robust check is the vmap == jit round-trip asserted below.
-EXPECTED_VMAP_LOG_LIKELIHOOD = -6146.59211318
+EXPECTED_VMAP_LOG_LIKELIHOOD = -3810.18711583
 
 np.testing.assert_allclose(
     np.array(result),


### PR DESCRIPTION
## What

Completes the kernel-CDF reference re-derivation that ef297b6 applied to the imaging rectangular scripts only. PyAutoArray #403 (linear → kernel-CDF rectangular meshes) deliberately shifted the rectangular-mesh numerics; the two **multi** rectangular scripts were missed and still asserted the pre-#403 literals, tripping their 1% gross-change guard in the nightly release-fidelity validation (PyAutoHeart run 30069528162).

## Changes (2 lines)

| Script | Old literal | New (measured) |
|---|---|---|
| `scripts/multi/jax_likelihood/rectangular.py` | −12928.70087095 | −8903.89296045 |
| `scripts/multi/jax_likelihood/rectangular_mge.py` | −6146.59211318 | −3810.18711583 |

Re-derived by running each script under the CI release profile (real search, full-res, JAX x64). Sanity: same sign, same order of magnitude, log-likelihood improves at the default bandwidth — the same direction and pattern as the imaging siblings in ef297b6 (imaging `rectangular_mge.py` shifted ~89% for the same adapt-weighting reason). The `rtol` guards and the exact vmap==jit round-trip assertions are untouched and both scripts pass end-to-end, including `PASS: jit(log_likelihood_function) round-trip matches vmap scalar.`

No notebooks involved; no other scripts' literals touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_