### PR TITLE
fix: re-depth visualization config paths after #216 restructure; herculens OPTIONAL-DEP skip

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -17,6 +17,15 @@
 #   permanent skips — every mega-run surfaces them with a loud warning
 #   banner. Investigate the failure, fix the underlying bug, and remove
 #   the NEEDS_FIX marker.
+#
+# OPTIONAL-DEP convention:
+#   Entries tagged `# OPTIONAL-DEP <YYYY-MM-DD> - <reason>` mark scripts that
+#   are correct as-is but import a third-party package that is deliberately
+#   NOT in the PyAuto install set (so it is absent from smoke / release
+#   validation environments). Not a to-do marker and not surfaced as a
+#   warning banner: the script stays on disk and is run by hand in an
+#   environment that has the dependency. Remove the entry if the dependency
+#   ever joins the validated install set.
 
 - misc/database/scrape/multi_analysis_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
 - misc/database/scrape/slam_general_jax # SLOW 2026-04-10 - exceeds 60s timeout; _test workspaces run full searches without test mode
@@ -70,3 +79,7 @@
 - misc/interop/coolest_round_trip.py # CULL-DEMOTE 2026-07-24 - COOLEST round-trip duplicated by validated autolens_workspace guides/coolest_interop.py; herculens parity sibling KEPT (#211)
 - cluster/csv_api.py # CULL-DEMOTE 2026-07-24 - regenerates the committed hand-authored dataset/cluster/test CSVs consumed directly by likelihood_sanity; identically-named validated user script covers the API (#211)
 - cluster/simulator.py # CULL-DEMOTE 2026-07-24 (protective) - stage 2 of the csv_api chain over hand-authored inputs; committed dataset/cluster/test carries calibrated parity consumers, skip so a mega-run cannot overwrite it (#211)
+
+# OPTIONAL-DEP skips — correct-as-is scripts whose third-party imports are not
+# in the validated install set.
+- misc/interop/coolest_herculens_parity.py # OPTIONAL-DEP 2026-07-24 - imports `herculens` (and `coolest`), neither of which is a PyAutoLens dependency nor in the release-validation install set; mode=release fails at `ModuleNotFoundError: No module named 'herculens'`. Script is correct and stays on disk (KEPT by #211) — run it by hand in an environment with herculens installed.

--- a/scripts/imaging/visualization/visualization.py
+++ b/scripts/imaging/visualization/visualization.py
@@ -52,8 +52,8 @@ from types import SimpleNamespace
 from autolens import conf
 
 conf.instance.push(
-    new_path=path.join(path.dirname(path.realpath(__file__)), "config"),
-    output_path=path.join(path.dirname(path.realpath(__file__)), "images"),
+    new_path=path.join(path.dirname(path.realpath(__file__)), "..", "config"),
+    output_path=path.join(path.dirname(path.realpath(__file__)), "..", "images"),
 )
 
 import numpy as np
@@ -318,8 +318,8 @@ Override the all-true config with a minimal one that only enables:
 All other toggles are explicitly set to false so no extra files are written.
 """
 conf.instance.push(
-    new_path=path.join(path.dirname(path.realpath(__file__)), "config_source"),
-    output_path=path.join(path.dirname(path.realpath(__file__)), "images"),
+    new_path=path.join(path.dirname(path.realpath(__file__)), "..", "config_source"),
+    output_path=path.join(path.dirname(path.realpath(__file__)), "..", "images"),
 )
 
 

--- a/scripts/imaging/visualization/visualization_jax.py
+++ b/scripts/imaging/visualization/visualization_jax.py
@@ -40,8 +40,8 @@ from types import SimpleNamespace
 from autolens import conf
 
 conf.instance.push(
-    new_path=path.join(path.dirname(path.realpath(__file__)), "config_source"),
-    output_path=path.join(path.dirname(path.realpath(__file__)), "images"),
+    new_path=path.join(path.dirname(path.realpath(__file__)), "..", "config_source"),
+    output_path=path.join(path.dirname(path.realpath(__file__)), "..", "images"),
 )
 
 import autofit as af

--- a/scripts/interferometer/visualization/visualization.py
+++ b/scripts/interferometer/visualization/visualization.py
@@ -50,8 +50,8 @@ from types import SimpleNamespace
 from autolens import conf
 
 conf.instance.push(
-    new_path=path.join(path.dirname(path.realpath(__file__)), "config"),
-    output_path=path.join(path.dirname(path.realpath(__file__)), "images"),
+    new_path=path.join(path.dirname(path.realpath(__file__)), "..", "config"),
+    output_path=path.join(path.dirname(path.realpath(__file__)), "..", "images"),
 )
 
 from astropy.io import fits as astropy_fits
@@ -309,8 +309,8 @@ Override the all-true config with a minimal one that only enables:
 All other toggles are explicitly set to false so no extra files are written.
 """
 conf.instance.push(
-    new_path=path.join(path.dirname(path.realpath(__file__)), "config_source"),
-    output_path=path.join(path.dirname(path.realpath(__file__)), "images"),
+    new_path=path.join(path.dirname(path.realpath(__file__)), "..", "config_source"),
+    output_path=path.join(path.dirname(path.realpath(__file__)), "..", "images"),
 )
 
 

--- a/scripts/multi/visualization/imaging.py
+++ b/scripts/multi/visualization/imaging.py
@@ -29,7 +29,7 @@ appears in the parameters. The result: the static method is never called.
 Run from the ``autolens_workspace_test`` repo root:
 
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
-        python scripts/multi/visualization_imaging.py
+        python scripts/multi/visualization/imaging.py
 
 __Env__
 
@@ -50,10 +50,10 @@ from autolens import conf
 
 conf.instance.push(
     new_path=path.join(
-        path.dirname(path.realpath(__file__)), "..", "imaging", "config"
+        path.dirname(path.realpath(__file__)), "..", "..", "imaging", "config"
     ),
     output_path=path.join(
-        path.dirname(path.realpath(__file__)), "..", "imaging", "images"
+        path.dirname(path.realpath(__file__)), "..", "..", "imaging", "images"
     ),
 )
 

--- a/scripts/multi/visualization/interferometer.py
+++ b/scripts/multi/visualization/interferometer.py
@@ -2,7 +2,7 @@
 Visualization: Multi-Channel Interferometer Analysis (FactorGraph / Datacube)
 =============================================================================
 
-Sibling of ``scripts/multi/visualization_imaging.py`` for the interferometer / ALMA
+Sibling of ``scripts/multi/visualization/imaging.py`` for the interferometer / ALMA
 datacube case. Verifies that ``VisualizerInterferometer.visualize_combined`` is
 invoked when a multi-channel interferometer fit runs through ``af.FactorGraphModel``
 and writes ``fit_combined.png`` with one row per channel.
@@ -27,7 +27,7 @@ sufficient — the goal is to confirm the plot lands, not to compare physics.
 Run from the ``autolens_workspace_test`` repo root:
 
     NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib \\
-        python scripts/multi/visualization_interferometer.py
+        python scripts/multi/visualization/interferometer.py
 """
 
 import shutil
@@ -40,10 +40,10 @@ from autolens import conf
 
 conf.instance.push(
     new_path=path.join(
-        path.dirname(path.realpath(__file__)), "..", "interferometer", "config"
+        path.dirname(path.realpath(__file__)), "..", "..", "interferometer", "config"
     ),
     output_path=path.join(
-        path.dirname(path.realpath(__file__)), "..", "interferometer", "images"
+        path.dirname(path.realpath(__file__)), "..", "..", "interferometer", "images"
     ),
 )
 


### PR DESCRIPTION
## What

Fixes 6 of the 11 release-validation failures from the nightly dry-run (PyAutoHeart run 30113021881) — the first release-profile run of the #216 mirror-taxonomy restructure.

**Config-path re-depth (5 scripts).** #216 `git mv`'d the visualization scripts one level down into `scripts/<dataset>/visualization/`, but their `conf.instance.push()` calls still resolve `config` / `config_source` / `images` from `path.dirname(__file__)` at the old depth, so each crashed on its first statement with `autonerves.exc.ConfigException`. The config dirs themselves did not move; the fix is purely path re-depthing (the `multi/` pair reach sideways into a sibling dataset folder, so they need two `..`), plus matching `images` output paths and stale docstring run-paths.

- `scripts/imaging/visualization/visualization.py`, `visualization_jax.py`
- `scripts/interferometer/visualization/visualization.py`
- `scripts/multi/visualization/imaging.py`, `interferometer.py`

**Herculens exclusion (1 script).** `scripts/misc/interop/coolest_herculens_parity.py` fails in release validation with `ModuleNotFoundError: No module named 'herculens'` — herculens is deliberately not in the validated install set (the script's own docstring says so). Added it to `config/build/no_run.yaml` under a new documented `OPTIONAL-DEP` tag (the repo's established exclusion mechanism; no optional-dep script here uses in-script guards), with a comment naming the missing dep and when to remove the entry. Verified the pattern matches only this script.

## Verification

All five edited scripts run fully green (exit 0, their own assertions passing) under the release-profile env against the current library mains. `no_run.yaml` entry checked against `build_util.should_skip`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_