### PR TITLE
config: persist samples.csv so resumed fits keep usable samples

### DIFF
--- a/config/output.yaml
+++ b/config/output.yaml
@@ -14,7 +14,7 @@ default: true # If true then files which are not explicitly listed here are outp
 # the `samples_summary.json` file. However, without a `samples.csv` file these types of tasks cannot be performed
 # after the fit is complete, for example via the database.
 
-samples: false
+samples: true
 
 # The `samples.csv` file contains every accepted sampled value of every free parameter with its log likelihood and
 # weight. For certain searches, the majority of samples have a very low weight and have no numerical impact on the


### PR DESCRIPTION
Completes the latent-resume follow-up from PyAutoFit#1418: `config/output.yaml` disabled `samples.csv` output, so any resumed completed fit reloaded `result.samples` as `None` — the latent scripts then failed on resume (cleanly, via #1418's `SamplesException`; an internal `AttributeError` before it). Flip `samples: true`: test-mode sample tables are tiny (4 fake rows by default), so the disk cost is negligible while resume becomes robust for every script that dereferences `result.samples`.

Verified: `latent_variables_smoke.py` and `latent_nan_robustness.py` both pass **fresh and resumed** (resume path confirmed taken) under the smoke env.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_